### PR TITLE
Fix: Setting a bound value causes RuntimeException

### DIFF
--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -103,6 +103,7 @@ class JsonPropertiesEditor(
 
 	private fun rebindValidProperty() {
 		if (idsToPanes.isEmpty()) {
+			valid_.unbind()
 			valid_.set(true)
 		} else {
 			valid_.bind(idsToPanes.values.map { it.valid as ObservableBooleanValue }.reduce { a, b -> Bindings.and(a, b) })


### PR DESCRIPTION
The value needs to be unbound before setting it.

Fixes #1 