### PR TITLE
Improvement: Wrap property panes in scrollbar pane

### DIFF
--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -13,6 +13,7 @@ import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.binding.Bindings
 import javafx.beans.value.ObservableBooleanValue
+import javafx.scene.control.ScrollPane
 
 class JsonPropertiesEditor(
 		private val referenceProposalProvider: IdReferenceProposalProvider = IdReferenceProposalProvider.IdReferenceProposalProviderEmpty,
@@ -21,7 +22,9 @@ class JsonPropertiesEditor(
 ) :
 	VBox() {
 	private val idsToPanes = mutableMapOf<String, JsonPropertiesPane>()
+	private val scrollPane = ScrollPane()
 	private val filterText = TextField()
+	private val paneContainer = VBox()
 	private val valid_ = SimpleBooleanProperty(true)
 	val valid: ReadOnlyBooleanProperty
 		get() = valid_
@@ -30,7 +33,9 @@ class JsonPropertiesEditor(
 	init {
 		filterText.promptText = "Filter properties";
 		filterText.textProperty().addListener { _, _, new -> idsToPanes.values.forEach { it.setPropertyFilter(new) } }
-		this.children.add(filterText)
+		scrollPane.content = paneContainer
+		scrollPane.isFitToWidth = true
+		this.children.addAll(filterText, scrollPane)
 	}
 
 	@JvmOverloads
@@ -50,7 +55,7 @@ class JsonPropertiesEditor(
 			createTitledPaneForSchema(title, obj, parseSchema(schema, resolutionScope), filterText.text, callback)
 		pane.fillData(obj)
 		idsToPanes[objId] = pane
-		children.add(pane)
+		paneContainer.children.add(pane)
 		if (idsToPanes.size <= numberOfInitiallyOpenedObjects) {
 			pane.isExpanded = true
 		}


### PR DESCRIPTION
Added a ScrollbarPane which holds a VBox with all property panes.
Horizontal and vertical scrollbars are added as needed (default behaviour).
Also this way the filter text field stays on top and the panes can still
be filtered while scrolling.