### PR TITLE
Fix: Displaying issues when clearing editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IntelliJ
+*.iml
+
 # Compiled class file
 *.class
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -96,12 +96,11 @@ class JsonPropertiesEditor(
 	}
 
 	fun clear() {
-		children.clear()
 		idsToPanes.clear()
 		filterText.clear()
+		paneContainer.children.clear()
 		rebindValidProperty()
 	}
-
 
 	private fun rebindValidProperty() {
 		if (idsToPanes.isEmpty()) {


### PR DESCRIPTION
Due to the removal of the root children the properties were not
displayed anymore after using the clear method. Now the pane container
which contains the property panes is cleared instead.

Minor change: Added IntelliJ-specific file to gitignore.
