### PR TITLE
Improve validation support, esp. for null values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.7</version>
+    <version>0.0.0.8</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>
@@ -119,12 +119,12 @@
             <artifactId>json</artifactId>
             <version>20200518</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.junit.jupiter</groupId>-->
-<!--            <artifactId>junit-jupiter</artifactId>-->
-<!--            <version>5.5.1</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
+        <!--        <dependency>-->
+        <!--            <groupId>org.junit.jupiter</groupId>-->
+        <!--            <artifactId>junit-jupiter</artifactId>-->
+        <!--            <version>5.5.1</version>-->
+        <!--            <scope>test</scope>-->
+        <!--        </dependency>-->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/StringControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/StringControl.kt
@@ -90,14 +90,14 @@ class StringControl(override val schema: SchemaWrapper<StringSchema>, context: E
             minLength != null -> Validator { control, value ->
                 ValidationResult.fromErrorIf(
                         control,
-                        "Has to be at max $minLength characters",
+                        "Has to be at least $minLength characters",
                         value?.length ?: 0 < minLength
                 )
             }
             maxLength != null -> Validator { control, value ->
                 ValidationResult.fromErrorIf(
                         control,
-                        "Has to be at least $maxLength characters",
+                        "Has to be at most $maxLength characters",
                         value?.length ?: 0 > maxLength
                 )
             }

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/StringControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/StringControl.kt
@@ -30,9 +30,14 @@ class StringControl(override val schema: SchemaWrapper<StringSchema>, context: E
 
     init {
         val validation = ValidationSupport()
-        addFormatValidation(validation, control, schema.schema.formatValidator)
-        addLengthValidation(validation, control, schema.schema.minLength, schema.schema.maxLength)
-        addPatternValidation(validation, control, schema.schema.pattern)
+        validation.initInitialDecoration()
+
+        validation.registerValidator(control, false, combineValidators(
+                createFormatValidation(schema.schema.formatValidator),
+                createLengthValidation(schema.schema.minLength, schema.schema.maxLength),
+                createPatternValidation(schema.schema.pattern)
+        ))
+
         valid.bind(validation.invalidProperty().not())
     }
 
@@ -116,6 +121,13 @@ class StringControl(override val schema: SchemaWrapper<StringSchema>, context: E
             }, "Has to match pattern $pattern", Severity.ERROR)
             validation.registerValidator(textField, false, validator)
             return validator
+        }
+
+        fun createPatternValidation(pattern: Pattern?): Validator<String?>? = when (pattern) {
+            null -> null
+            else -> Validator.createPredicateValidator({ it: String? ->
+                it == null || pattern.matcher(it).matches()
+            }, "Has to match pattern $pattern", Severity.ERROR)
         }
     }
 }

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ValidationHelper.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ValidationHelper.kt
@@ -1,10 +1,15 @@
 package com.github.hanseter.json.editor.controls
 
 import javafx.beans.property.Property
+import javafx.beans.value.ChangeListener
+import javafx.beans.value.ObservableValue
 import javafx.scene.Node
+import javafx.scene.control.Control
+import javafx.scene.control.Skin
 import org.controlsfx.control.decoration.Decorator
 import org.controlsfx.validation.ValidationMessage
 import org.controlsfx.validation.ValidationResult
+import org.controlsfx.validation.Validator
 import org.controlsfx.validation.decoration.GraphicValidationDecoration
 
 fun redecorate(node: Node?, vararg messages: Property<ValidationMessage?>) {
@@ -26,4 +31,24 @@ fun redecorate(node: Node?, results: List<ValidationResult?>) {
         GraphicValidationDecoration().applyValidationDecoration(it.warnings.first())
         return
     }
+}
+
+fun runAfterSkinLoads(node: Control, runnable: () -> Unit) {
+    if (node.skin != null) {
+        runnable()
+    } else {
+        node.skinProperty().addListener(object : ChangeListener<Skin<*>> {
+            override fun changed(observable: ObservableValue<out Skin<*>>?, oldValue: Skin<*>?, newValue: Skin<*>?) {
+                if (newValue != null) {
+                    runnable()
+                    node.skinProperty().removeListener(this)
+                }
+            }
+
+        })
+    }
+}
+
+fun <T> combineValidators(vararg validators: Validator<T>?): Validator<T> {
+    return Validator.combine(*validators.filterNotNull().toTypedArray())
 }

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -57,6 +57,22 @@ class JsonPropertiesEditorTestApp : Application() {
             }
         """)
 
+        val completeValidationInvalidData = JSONObject("""
+{
+  "strings": {
+    "maxLength": "abcdefghi",
+    "minLength": "a"
+  },
+  "lists": {
+    "minItems": ["foo"],
+    "uniqueItems": ["d", "d"]
+  },
+  "id-references": {
+    "pattern": "H"
+  }
+}
+        """)
+
         val schema = JSONObject(JSONTokener(this::class.java.classLoader.getResourceAsStream(
 //                "nestedCompositeSchema.json"
 //                "resettableSchema.json"
@@ -84,8 +100,13 @@ class JsonPropertiesEditorTestApp : Application() {
 //		propEdit.display("test3", "test3", testData, schema) { it }
 
         val d = JSONObject("""{"type":"object","properties":{"str":{"type":"string"}, "num":{"type":"number"}}}""")
+/*
         val data = JSONObject("""{"num":42.5,"str":"Hello"}""")
-        propEdit.display("1", "1", data, schema) { println(it.toString(1));it }
+
+ */
+
+
+        propEdit.display("1", "1", completeValidationInvalidData, schema) { println(it.toString(1));it }
         propEdit.valid.addListener { _, _, new -> println("Is valid: $new") }
         primaryStage.scene = Scene(propEdit, 800.0, 800.0)
         primaryStage.show()

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -59,8 +59,9 @@ class JsonPropertiesEditorTestApp : Application() {
 
         val schema = JSONObject(JSONTokener(this::class.java.classLoader.getResourceAsStream(
 //                "nestedCompositeSchema.json"
-                "resettableSchema.json"
+//                "resettableSchema.json"
 //                "deepSchema.json"
+                "completeValidationTestSchema.json"
         )))
 //		val schema = JSONObject(JSONTokener(this::class.java.getClassLoader().getResourceAsStream("StringSchema.json")))
 
@@ -84,7 +85,7 @@ class JsonPropertiesEditorTestApp : Application() {
 
         val d = JSONObject("""{"type":"object","properties":{"str":{"type":"string"}, "num":{"type":"number"}}}""")
         val data = JSONObject("""{"num":42.5,"str":"Hello"}""")
-        propEdit.display("1", "1", data, d) { println(it.toString(1));it }
+        propEdit.display("1", "1", data, schema) { println(it.toString(1));it }
         propEdit.valid.addListener { _, _, new -> println("Is valid: $new") }
         primaryStage.scene = Scene(propEdit, 800.0, 800.0)
         primaryStage.show()

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -1,0 +1,157 @@
+{
+  "title": "completeValidationTest",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "properties": {
+    "strings": {
+      "type": "object",
+      "properties": {
+        "req": {
+          "type": "string"
+        },
+        "minLength": {
+          "type": "string",
+          "minLength": 3
+        },
+        "maxLength": {
+          "type": "string",
+          "maxLength": 6
+        },
+        "minMaxLength": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 6
+        },
+        "pattern": {
+          "type": "string",
+          "pattern": "foo.+bar"
+        },
+        "formats": {
+          "type": "object",
+          "properties": {
+            "date-time": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "time": {
+              "type": "string",
+              "format": "time"
+            },
+            "date": {
+              "type": "string",
+              "format": "date"
+            },
+            "email": {
+              "type": "string",
+              "format": "email"
+            },
+            "idn-email": {
+              "type": "string",
+              "format": "idn-email"
+            },
+            "hostname": {
+              "type": "string",
+              "format": "hostname"
+            },
+            "idn-hostname": {
+              "type": "string",
+              "format": "idn-hostname"
+            },
+            "ipv4": {
+              "type": "string",
+              "format": "ipv4"
+            },
+            "ipv6": {
+              "type": "string",
+              "format": "ipv6"
+            },
+            "uri": {
+              "type": "string",
+              "format": "uri"
+            },
+            "uri-reference": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "iri": {
+              "type": "string",
+              "format": "iri"
+            },
+            "iri-reference": {
+              "type": "string",
+              "format": "iri-reference"
+            },
+            "uri-template": {
+              "type": "string",
+              "format": "uri-template"
+            },
+            "json-pointer": {
+              "type": "string",
+              "format": "json-pointer"
+            },
+            "relative-json-pointer": {
+              "type": "string",
+              "format": "relative-json-pointer"
+            },
+            "regex": {
+              "type": "string",
+              "format": "regex"
+            }
+          }
+        }
+      },
+      "required": [
+        "req"
+      ]
+    },
+    "integers": {
+      "type": "object",
+      "properties": {
+        "multipleOf": {
+          "type": "integer",
+          "multipleOf": 3
+        },
+        "minimum": {
+          "type": "integer",
+          "minimum": 3
+        },
+        "exclusiveMinimum": {
+          "type": "integer",
+          "exclusiveMinimum": 3
+        },
+        "maximum": {
+          "type": "integer",
+          "maximum": 6
+        },
+        "exclusiveMaximum": {
+          "type": "integer",
+          "exclusiveMaximum": 6
+        }
+      }
+    },
+    "numbers": {
+      "type": "object",
+      "properties": {
+        "multipleOf": {
+          "type": "number",
+          "multipleOf": 3
+        },
+        "minimum": {
+          "type": "number",
+          "minimum": 3
+        },
+        "exclusiveMinimum": {
+          "type": "number",
+          "exclusiveMinimum": 3
+        },
+        "maximum": {
+          "type": "number",
+          "maximum": 6
+        },
+        "exclusiveMaximum": {
+          "type": "number",
+          "exclusiveMaximum": 6
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -25,6 +25,12 @@
           "type": "string",
           "pattern": "foo.+bar"
         },
+        "minMaxPattern": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 8,
+          "pattern": "foo.+bar"
+        },
         "formats": {
           "type": "object",
           "properties": {
@@ -150,6 +156,49 @@
         "exclusiveMaximum": {
           "type": "number",
           "exclusiveMaximum": 6
+        }
+      }
+    },
+    "lists": {
+      "type": "object",
+      "properties": {
+        "minItems": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 3
+        },
+        "maxItems": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 6
+        },
+        "uniqueItems": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "childValidation": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      }
+    },
+    "id-references": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "format": "id-reference",
+          "pattern": "G.+"
         }
       }
     }


### PR DESCRIPTION
- All validators registered now only run when the current value is non-null.
- For String and ID Reference fields, multiple validators now run properly.
- The validation error decorations should be displayed immediately, and not only after editing (only for Strings, ID References, and Arrays, since other types don't use error decorations).
  - in some cases (possibly notable for future changes as well), the decoration should only be set after the control's skin is initialized because some skins clear the previous children.
- Double spinners no longer throw an exception if the increment/decrement buttons are used while the value is `null`.