### PR TITLE
Ensure that decorations don't vanish when JavaFx updates labels.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.8</version>
+    <version>0.0.0.9</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -138,9 +138,7 @@ class JsonPropertiesEditor(
 
     private fun createTitledPaneForSchema(title: String, data: JSONObject,
                                           schema: Schema, callback: (JSONObject) -> JSONObject): JsonPropertiesPane =
-            JsonPropertiesPane(title, data, schema, referenceProposalProvider, actions, validators) { obj, pane ->
-                pane.fillData(callback(obj))
-            }
+            JsonPropertiesPane(title, data, schema, referenceProposalProvider, actions, validators, callback)
 
     private fun initTreeTableView() {
         val keyColumn = createKeyColumn()

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -24,7 +24,7 @@ class JsonPropertiesPane(
         private val refProvider: IdReferenceProposalProvider,
         private val actions: List<EditorAction>,
         private val validators: List<com.github.hanseter.json.editor.validators.Validator>,
-        private val changeListener: (JSONObject, JsonPropertiesPane) -> Unit
+        private val changeListener: (JSONObject) -> JSONObject
 ) {
     val treeItem: FilterableTreeItem<TreeItemData> = FilterableTreeItem(SectionRootTreeItemData(title))
     private val schema = RegularSchemaWrapper(null, schema, title)
@@ -54,8 +54,8 @@ class JsonPropertiesPane(
         val actions = ActionsContainer(control, actions) { e, action, control ->
             val ret = action.apply(contentHandler.data, control.model, e)
             if (ret != null) {
-                changeListener(ret, this)
-                fillData(ret)
+                val newData = changeListener(ret)
+                fillData(newData)
             }
         }
 
@@ -78,7 +78,8 @@ class JsonPropertiesPane(
         objectControl?.bindTo(type)
         fillTree()
         type.registerListener {
-            changeListener(type.value!!, this)
+            val newData = changeListener(type.value!!)
+            fillData(newData)
         }
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/extensions/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/extensions/FilterableTreeItem.kt
@@ -2,6 +2,7 @@ package com.github.hanseter.json.editor.extensions
 
 import com.github.hanseter.json.editor.actions.ActionsContainer
 import com.github.hanseter.json.editor.controls.TypeControl
+import com.github.hanseter.json.editor.util.DecoratableLabelSkin
 import javafx.beans.binding.Bindings
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
@@ -116,6 +117,7 @@ class ControlTreeItemData(
         val validators: List<com.github.hanseter.json.editor.validators.Validator>) : TreeItemData {
     override val label = Label(typeControl.model.schema.title).apply {
         tooltip = typeControl.model.schema.schema.description?.let { Tooltip(it) }
+        skin = DecoratableLabelSkin(this)
     }
     override val control: Node?
         get() = typeControl.control

--- a/src/main/kotlin/com/github/hanseter/json/editor/util/DecoratableLabelSkin.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/util/DecoratableLabelSkin.kt
@@ -1,0 +1,23 @@
+package com.github.hanseter.json.editor.util
+
+import com.sun.javafx.scene.control.skin.LabelSkin
+import javafx.scene.control.Label
+import org.controlsfx.control.decoration.Decorator
+
+/**
+ * Skin for labels that preserves any decorations added to it.
+ *
+ * This should be set as soon as possible after the label's construction for maximum effect.
+ */
+class DecoratableLabelSkin(label: Label) : LabelSkin(label) {
+    override fun updateChildren() {
+        val decorations = Decorator.getDecorations(skinnable)?.toList() ?: listOf()
+        Decorator.removeAllDecorations(skinnable)
+
+        super.updateChildren()
+
+        decorations.forEach {
+            Decorator.addDecoration(skinnable, it)
+        }
+    }
+}


### PR DESCRIPTION
The default `LabelSkin` will remove all children except the text and the graphic when `updateChildren` is invoked by the JavaFx Application Thread. This causes validation decorations to not appear reliably, or to suddenly disappear.

`LabelSkin` was subclassed to restore all decorations during `updateChildren`.