### PR TITLE
Add View Options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.10</version>
+    <version>0.0.0.11</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.11</version>
+    <version>0.0.0.12</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.9</version>
+    <version>0.0.0.10</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -7,6 +7,7 @@ import com.github.hanseter.json.editor.extensions.RootTreeItemData
 import com.github.hanseter.json.editor.extensions.TreeItemData
 import com.github.hanseter.json.editor.schemaExtensions.ColorFormat
 import com.github.hanseter.json.editor.schemaExtensions.IdReferenceFormat
+import com.github.hanseter.json.editor.util.ViewOptions
 import com.github.hanseter.json.editor.validators.ArrayValidator
 import com.github.hanseter.json.editor.validators.RequiredValidator
 import com.github.hanseter.json.editor.validators.StringValidator
@@ -32,8 +33,9 @@ class JsonPropertiesEditor(
         private val readOnly: Boolean = false,
         private val numberOfInitiallyOpenedObjects: Int = 5,
         private val resolutionScopeProvider: ResolutionScopeProvider = ResolutionScopeProvider.ResolutionScopeProviderEmpty,
+        private val viewOptions: ViewOptions = ViewOptions(),
         actions: List<EditorAction> = listOf(ResetToDefaultAction, ResetToNullAction),
-        private val validators: List<Validator> = listOf(StringValidator, ArrayValidator, RequiredValidator)
+        private val validators: List<Validator> = listOf(StringValidator, ArrayValidator, RequiredValidator),
 ) : VBox() {
     private val actions = actions + PreviewAction(referenceProposalProvider, resolutionScopeProvider) + arrayActions
     private val idsToPanes = mutableMapOf<String, JsonPropertiesPane>()
@@ -55,7 +57,7 @@ class JsonPropertiesEditor(
                     if (newValue.isEmpty()) {
                         Predicate { true }
                     } else {
-                        Predicate { it.label.text.contains(newValue) }
+                        Predicate { it.title.contains(newValue) }
                     })
         }
 
@@ -138,7 +140,7 @@ class JsonPropertiesEditor(
 
     private fun createTitledPaneForSchema(title: String, data: JSONObject,
                                           schema: Schema, callback: (JSONObject) -> JSONObject): JsonPropertiesPane =
-            JsonPropertiesPane(title, data, schema, referenceProposalProvider, actions, validators, callback)
+            JsonPropertiesPane(title, data, schema, referenceProposalProvider, actions, validators, viewOptions, callback)
 
     private fun initTreeTableView() {
         val keyColumn = createKeyColumn()

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -33,7 +33,7 @@ class JsonPropertiesEditor(
         private val readOnly: Boolean = false,
         private val numberOfInitiallyOpenedObjects: Int = 5,
         private val resolutionScopeProvider: ResolutionScopeProvider = ResolutionScopeProvider.ResolutionScopeProviderEmpty,
-        private val viewOptions: ViewOptions = ViewOptions(),
+        private var viewOptions: ViewOptions = ViewOptions(),
         actions: List<EditorAction> = listOf(ResetToDefaultAction, ResetToNullAction),
         private val validators: List<Validator> = listOf(StringValidator, ArrayValidator, RequiredValidator),
 ) : VBox() {
@@ -127,6 +127,12 @@ class JsonPropertiesEditor(
         filterText.clear()
         (treeTableView.root as FilterableTreeItem).clear()
         rebindValidProperty()
+    }
+
+    fun updateViewOptions(viewOptions: ViewOptions) {
+        this.viewOptions = viewOptions
+
+        idsToPanes.values.forEach { it.updateViewOptions(viewOptions) }
     }
 
     private fun rebindValidProperty() {

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -6,7 +6,9 @@ import com.github.hanseter.json.editor.controls.ObjectControl
 import com.github.hanseter.json.editor.controls.TypeControl
 import com.github.hanseter.json.editor.extensions.*
 import com.github.hanseter.json.editor.util.EditorContext
+import com.github.hanseter.json.editor.util.PropertyGrouping
 import com.github.hanseter.json.editor.util.RootBindableType
+import com.github.hanseter.json.editor.util.ViewOptions
 import javafx.application.Platform
 import javafx.beans.binding.Bindings
 import javafx.beans.property.SimpleBooleanProperty
@@ -24,6 +26,7 @@ class JsonPropertiesPane(
         private val refProvider: IdReferenceProposalProvider,
         private val actions: List<EditorAction>,
         private val validators: List<com.github.hanseter.json.editor.validators.Validator>,
+        private val viewOptions: ViewOptions,
         private val changeListener: (JSONObject) -> JSONObject
 ) {
     val treeItem: FilterableTreeItem<TreeItemData> = FilterableTreeItem(SectionRootTreeItemData(title))
@@ -60,9 +63,9 @@ class JsonPropertiesPane(
         }
 
         val item: FilterableTreeItem<TreeItemData> =
-                FilterableTreeItem(ControlTreeItemData(control, actions, validators.filter { it.selector.matches(control.model) }))
+                FilterableTreeItem(ControlTreeItemData(control, actions, validators.filter { it.selector.matches(control.model) }, viewOptions))
         if (control is ObjectControl) {
-            addRequiredAndOptionalChildren(item, control.requiredChildren, control.optionalChildren)
+            addObjectControlChildren(item, control)
         } else {
             item.list.setAll(control.childControls.map { wrapControlInTreeItem(it) })
         }
@@ -96,7 +99,7 @@ class JsonPropertiesPane(
         if (control is ObjectControl) {
             if (item.isLeaf) {
                 if (control.childControls.isNotEmpty()) {
-                    addRequiredAndOptionalChildren(item, control.requiredChildren, control.optionalChildren)
+                    addObjectControlChildren(item, control)
                 }
             } else {
                 if (control.childControls.isEmpty()) {
@@ -114,6 +117,30 @@ class JsonPropertiesPane(
         }
         item.children.forEach { item ->
             (item.value as? ControlTreeItemData)?.also { updateTree(item as FilterableTreeItem<TreeItemData>, it.typeControl) }
+        }
+    }
+
+    private fun addObjectControlChildren(node: FilterableTreeItem<TreeItemData>, control: ObjectControl) {
+        if (viewOptions.groupBy == PropertyGrouping.REQUIRED) {
+            addRequiredAndOptionalChildren(node, control.requiredChildren, control.optionalChildren)
+        } else {
+            val propOrder = control.model.schema.getPropertyOrder()
+
+            node.addAll(control.childControls.sortedWith { o1, o2 ->
+                val prop1 = o1.model.schema.getPropertyName()
+                val prop2 = o2.model.schema.getPropertyName()
+
+                val index1 = propOrder.indexOf(prop1).let { if (it == -1) Int.MAX_VALUE else it }
+                val index2 = propOrder.indexOf(prop2).let { if (it == -1) Int.MAX_VALUE else it }
+
+                val compareOrdered = index1.compareTo(index2)
+
+                if (compareOrdered != 0) {
+                    compareOrdered
+                } else {
+                    o1.model.schema.title.toLowerCase().compareTo(o2.model.schema.title.toLowerCase())
+                }
+            }.map { wrapControlInTreeItem(it) })
         }
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -30,7 +30,7 @@ class JsonPropertiesPane(
         private val refProvider: IdReferenceProposalProvider,
         private val actions: List<EditorAction>,
         private val validators: List<com.github.hanseter.json.editor.validators.Validator>,
-        private val viewOptions: ViewOptions,
+        private var viewOptions: ViewOptions,
         private val changeListener: (JSONObject) -> JSONObject
 ) {
     val treeItem: FilterableTreeItem<TreeItemData> = FilterableTreeItem(SectionRootTreeItemData(title))
@@ -78,6 +78,14 @@ class JsonPropertiesPane(
 
     fun fillData(data: JSONObject) {
         contentHandler.updateData(data)
+    }
+
+    fun updateViewOptions(viewOptions: ViewOptions) {
+        this.viewOptions = viewOptions
+
+        treeItem.clear()
+        initObjectControl()
+        contentHandler.updateData(contentHandler.data)
     }
 
     private fun fillSheet(data: JSONObject) {

--- a/src/main/kotlin/com/github/hanseter/json/editor/actions/ArrayActions.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/actions/ArrayActions.kt
@@ -20,7 +20,9 @@ object AddToArrayAction : EditorAction {
 
     override fun apply(currentData: JSONObject, model: TypeModel<*, *>, mouseEvent: Event?): JSONObject? {
         val children = (model as TypeModel<JSONArray?, SupportedType.ComplexType.ArrayType>).value
-                ?: JSONArray()
+                ?: JSONArray().also {
+                    model.value = it
+                }
         val childDefaultValue = (model.schema.baseSchema as ArraySchema).allItemSchema.defaultValue
         children.put(children.length(), childDefaultValue ?: JSONObject.NULL)
         return currentData

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
@@ -1,13 +1,14 @@
 package com.github.hanseter.json.editor.controls
 
 import com.github.hanseter.json.editor.ControlFactory
-import com.github.hanseter.json.editor.extensions.EffectiveSchemaInArray
 import com.github.hanseter.json.editor.extensions.EffectiveSchema
+import com.github.hanseter.json.editor.extensions.EffectiveSchemaInArray
 import com.github.hanseter.json.editor.types.ArrayModel
 import com.github.hanseter.json.editor.util.BindableJsonArray
 import com.github.hanseter.json.editor.util.BindableJsonArrayEntry
 import com.github.hanseter.json.editor.util.BindableJsonType
 import com.github.hanseter.json.editor.util.EditorContext
+import com.github.hanseter.json.editor.validators.isRequiredSchema
 import org.everit.json.schema.ArraySchema
 import org.json.JSONArray
 import org.json.JSONObject
@@ -54,11 +55,8 @@ class ArrayControl(override val model: ArrayModel, private val context: EditorCo
 
         val subArray = subArray
         val rawValues = model.rawValue
-        var values = rawValues as? JSONArray
-        if (rawValues != JSONObject.NULL) {
-            if (values == null) {
-                values = JSONArray()
-            }
+        val values = rawValues as? JSONArray
+        if (rawValues != JSONObject.NULL && values != null) {
             removeChildControls(values)
             addChildControls(values)
             rebindChildren(subArray, values)
@@ -71,7 +69,7 @@ class ArrayControl(override val model: ArrayModel, private val context: EditorCo
     }
 
     private fun updateLabel() {
-        if (model.rawValue == JSONObject.NULL) {
+        if (model.rawValue == JSONObject.NULL || model.rawValue == null) {
             control.displayNull()
         } else {
             control.displayNonNull("[${childControls.size} Element${if (childControls.size == 1) "" else "s"}]")
@@ -82,7 +80,7 @@ class ArrayControl(override val model: ArrayModel, private val context: EditorCo
 fun createSubArray(parent: BindableJsonType, schema: EffectiveSchema<ArraySchema>): BindableJsonArray? {
     val rawArr = parent.getValue(schema)
 
-    if (rawArr == JSONObject.NULL) {
+    if (rawArr == JSONObject.NULL || (rawArr == null && !isRequiredSchema(schema))) {
         return null
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
@@ -8,6 +8,7 @@ import com.github.hanseter.json.editor.util.BindableJsonArray
 import com.github.hanseter.json.editor.util.BindableJsonArrayEntry
 import com.github.hanseter.json.editor.util.BindableJsonType
 import com.github.hanseter.json.editor.util.EditorContext
+import com.github.hanseter.json.editor.validators.isRequiredSchema
 import org.everit.json.schema.ArraySchema
 import org.json.JSONArray
 import org.json.JSONObject
@@ -79,7 +80,7 @@ class ArrayControl(override val model: ArrayModel, private val context: EditorCo
 fun createSubArray(parent: BindableJsonType, schema: EffectiveSchema<ArraySchema>): BindableJsonArray? {
     val rawArr = parent.getValue(schema)
 
-    if (rawArr == JSONObject.NULL /*|| (rawArr == null && !isRequiredSchema(schema))*/) {
+    if (rawArr == JSONObject.NULL || (rawArr == null && !isRequiredSchema(schema))) {
         return null
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
@@ -8,7 +8,6 @@ import com.github.hanseter.json.editor.util.BindableJsonArray
 import com.github.hanseter.json.editor.util.BindableJsonArrayEntry
 import com.github.hanseter.json.editor.util.BindableJsonType
 import com.github.hanseter.json.editor.util.EditorContext
-import com.github.hanseter.json.editor.validators.isRequiredSchema
 import org.everit.json.schema.ArraySchema
 import org.json.JSONArray
 import org.json.JSONObject
@@ -80,7 +79,7 @@ class ArrayControl(override val model: ArrayModel, private val context: EditorCo
 fun createSubArray(parent: BindableJsonType, schema: EffectiveSchema<ArraySchema>): BindableJsonArray? {
     val rawArr = parent.getValue(schema)
 
-    if (rawArr == JSONObject.NULL || (rawArr == null && !isRequiredSchema(schema))) {
+    if (rawArr == JSONObject.NULL /*|| (rawArr == null && !isRequiredSchema(schema))*/) {
         return null
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/CombinedObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/CombinedObjectControl.kt
@@ -11,8 +11,8 @@ class CombinedObjectControl(override val model: CombinedObjectModel, val control
     override val allRequiredChildren = controls.flatMap { it.allRequiredChildren }.distinctBy { it.model.schema.title }
     override val allOptionalChildren = controls.flatMap { it.allOptionalChildren }.distinctBy { it.model.schema.title }
 
-    override var requiredChildren: List<TypeControl> = emptyList()
-    override var optionalChildren: List<TypeControl> = emptyList()
+    override var requiredChildren: List<TypeControl> = allRequiredChildren
+    override var optionalChildren: List<TypeControl> = allOptionalChildren
 
     override val control = TypeWithChildrenStatusControl("Create") {
         model.value = JSONObject()

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/CombinedObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/CombinedObjectControl.kt
@@ -2,13 +2,14 @@ package com.github.hanseter.json.editor.controls
 
 import com.github.hanseter.json.editor.types.CombinedObjectModel
 import com.github.hanseter.json.editor.util.BindableJsonType
+import com.github.hanseter.json.editor.validators.isRequiredSchema
 import org.json.JSONObject
 
 class CombinedObjectControl(override val model: CombinedObjectModel, val controls: List<ObjectControl>)
     : ObjectControl {
 
-    private val requiredChildrenNotNull = controls.flatMap { it.requiredChildren }.distinctBy { it.model.schema.title }
-    private val optionalChildrenNotNull = controls.flatMap { it.optionalChildren }.distinctBy { it.model.schema.title }
+    override val allRequiredChildren = controls.flatMap { it.allRequiredChildren }.distinctBy { it.model.schema.title }
+    override val allOptionalChildren = controls.flatMap { it.allOptionalChildren }.distinctBy { it.model.schema.title }
 
     override var requiredChildren: List<TypeControl> = emptyList()
     override var optionalChildren: List<TypeControl> = emptyList()
@@ -21,11 +22,11 @@ class CombinedObjectControl(override val model: CombinedObjectModel, val control
 
         controls.forEach { it.bindTo(type) }
         model.bound = type
-/*
+
         if (model.rawValue == null && isRequiredSchema(model.schema)) {
             model.value = JSONObject()
         }
-*/
+
         valueChanged()
 
 
@@ -34,8 +35,8 @@ class CombinedObjectControl(override val model: CombinedObjectModel, val control
     private fun valueChanged() {
         if (model.value != null) {
             if (requiredChildren.isEmpty() && optionalChildren.isEmpty()) {
-                requiredChildren = requiredChildrenNotNull
-                optionalChildren = optionalChildrenNotNull
+                requiredChildren = allRequiredChildren
+                optionalChildren = allOptionalChildren
             }
 
         } else {

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/CombinedObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/CombinedObjectControl.kt
@@ -2,22 +2,52 @@ package com.github.hanseter.json.editor.controls
 
 import com.github.hanseter.json.editor.types.CombinedObjectModel
 import com.github.hanseter.json.editor.util.BindableJsonType
-import javafx.scene.Node
+import org.json.JSONObject
 
 class CombinedObjectControl(override val model: CombinedObjectModel, val controls: List<ObjectControl>)
     : ObjectControl {
 
-    // Note: This control does not properly support explicit null values.
-    // However, it breaks if it appears anywhere but the root anyway, so that's not a real problem (yet)
-    override val requiredChildren: List<TypeControl> = controls.flatMap { it.requiredChildren }.distinctBy { it.model.schema.title }
-    override val optionalChildren: List<TypeControl> = controls.flatMap { it.optionalChildren }.distinctBy { it.model.schema.title }
+    private val requiredChildrenNotNull = controls.flatMap { it.requiredChildren }.distinctBy { it.model.schema.title }
+    private val optionalChildrenNotNull = controls.flatMap { it.optionalChildren }.distinctBy { it.model.schema.title }
 
-    override val control: Node?
-        get() = null
+    override var requiredChildren: List<TypeControl> = emptyList()
+    override var optionalChildren: List<TypeControl> = emptyList()
+
+    override val control = TypeWithChildrenStatusControl("Create") {
+        model.value = JSONObject()
+    }
 
     override fun bindTo(type: BindableJsonType) {
+
         controls.forEach { it.bindTo(type) }
         model.bound = type
+/*
+        if (model.rawValue == null && isRequiredSchema(model.schema)) {
+            model.value = JSONObject()
+        }
+*/
+        valueChanged()
+
+
+    }
+
+    private fun valueChanged() {
+        if (model.value != null) {
+            if (requiredChildren.isEmpty() && optionalChildren.isEmpty()) {
+                requiredChildren = requiredChildrenNotNull
+                optionalChildren = optionalChildrenNotNull
+            }
+
+        } else {
+            requiredChildren = emptyList()
+            optionalChildren = emptyList()
+        }
+
+        if (model.rawValue == JSONObject.NULL || model.rawValue == null) {
+            control.displayNull()
+        } else {
+            control.displayNonNull("")
+        }
     }
 
 }

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ObjectControl.kt
@@ -4,6 +4,9 @@ interface ObjectControl : TypeControl {
     val requiredChildren: List<TypeControl>
     val optionalChildren: List<TypeControl>
 
+    val allRequiredChildren: List<TypeControl>
+    val allOptionalChildren: List<TypeControl>
+
     override val childControls: List<TypeControl>
         get() = requiredChildren + optionalChildren
 }

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
@@ -14,20 +14,20 @@ class PlainObjectControl(override val model: PlainObjectModel, context: EditorCo
         model.value = JSONObject()
     }
 
-    private val requiredChildrenNotNull: List<TypeControl>
-    private val optionalChildrenNotNull: List<TypeControl>
+    override val allRequiredChildren: List<TypeControl>
+    override val allOptionalChildren: List<TypeControl>
 
     override var requiredChildren: List<TypeControl> = emptyList()
     override var optionalChildren: List<TypeControl> = emptyList()
 
     init {
         val childSchemas = model.schema.baseSchema.propertySchemas.toMutableMap()
-        requiredChildrenNotNull = createTypeControlsFromSchemas(model.schema, model.schema.baseSchema.requiredProperties.mapNotNull {
+        allRequiredChildren = createTypeControlsFromSchemas(model.schema, model.schema.baseSchema.requiredProperties.mapNotNull {
             childSchemas.remove(it)
         }, context)
-        optionalChildrenNotNull = createTypeControlsFromSchemas(model.schema, childSchemas.values, context)
-        requiredChildren = requiredChildrenNotNull
-        optionalChildren = optionalChildrenNotNull
+        allOptionalChildren = createTypeControlsFromSchemas(model.schema, childSchemas.values, context)
+        requiredChildren = allRequiredChildren
+        optionalChildren = allOptionalChildren
     }
 
 
@@ -42,8 +42,8 @@ class PlainObjectControl(override val model: PlainObjectModel, context: EditorCo
 
         if (subType != null) {
             if (requiredChildren.isEmpty() && optionalChildren.isEmpty()) {
-                requiredChildren = requiredChildrenNotNull
-                optionalChildren = optionalChildrenNotNull
+                requiredChildren = allRequiredChildren
+                optionalChildren = allOptionalChildren
             }
 
             bindChildrenToObject(subType)

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
@@ -4,7 +4,6 @@ import com.github.hanseter.json.editor.types.PlainObjectModel
 import com.github.hanseter.json.editor.util.BindableJsonObject
 import com.github.hanseter.json.editor.util.BindableJsonType
 import com.github.hanseter.json.editor.util.EditorContext
-import com.github.hanseter.json.editor.validators.isRequiredSchema
 import org.json.JSONObject
 
 class PlainObjectControl(override val model: PlainObjectModel, context: EditorContext)
@@ -65,7 +64,7 @@ class PlainObjectControl(override val model: PlainObjectModel, context: EditorCo
 
     private fun createSubType(parent: BindableJsonType): BindableJsonObject? {
         val rawObj = parent.getValue(model.schema)
-        if (rawObj == JSONObject.NULL || (rawObj == null && !isRequiredSchema(model.schema))) {
+        if (rawObj == JSONObject.NULL /*|| (rawObj == null && !isRequiredSchema(model.schema))*/) {
             return null
         }
         var obj = rawObj as? JSONObject

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
@@ -4,6 +4,7 @@ import com.github.hanseter.json.editor.types.PlainObjectModel
 import com.github.hanseter.json.editor.util.BindableJsonObject
 import com.github.hanseter.json.editor.util.BindableJsonType
 import com.github.hanseter.json.editor.util.EditorContext
+import com.github.hanseter.json.editor.validators.isRequiredSchema
 import org.json.JSONObject
 
 class PlainObjectControl(override val model: PlainObjectModel, context: EditorContext)
@@ -54,7 +55,7 @@ class PlainObjectControl(override val model: PlainObjectModel, context: EditorCo
     }
 
     private fun valueChanged() {
-        if (model.rawValue == JSONObject.NULL) {
+        if (model.rawValue == JSONObject.NULL || model.rawValue == null) {
             control.displayNull()
         } else {
             val size = requiredChildren.size + optionalChildren.size
@@ -64,7 +65,7 @@ class PlainObjectControl(override val model: PlainObjectModel, context: EditorCo
 
     private fun createSubType(parent: BindableJsonType): BindableJsonObject? {
         val rawObj = parent.getValue(model.schema)
-        if (rawObj == JSONObject.NULL) {
+        if (rawObj == JSONObject.NULL || (rawObj == null && !isRequiredSchema(model.schema))) {
             return null
         }
         var obj = rawObj as? JSONObject

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/PlainObjectControl.kt
@@ -4,6 +4,7 @@ import com.github.hanseter.json.editor.types.PlainObjectModel
 import com.github.hanseter.json.editor.util.BindableJsonObject
 import com.github.hanseter.json.editor.util.BindableJsonType
 import com.github.hanseter.json.editor.util.EditorContext
+import com.github.hanseter.json.editor.validators.isRequiredSchema
 import org.json.JSONObject
 
 class PlainObjectControl(override val model: PlainObjectModel, context: EditorContext)
@@ -64,7 +65,7 @@ class PlainObjectControl(override val model: PlainObjectModel, context: EditorCo
 
     private fun createSubType(parent: BindableJsonType): BindableJsonObject? {
         val rawObj = parent.getValue(model.schema)
-        if (rawObj == JSONObject.NULL /*|| (rawObj == null && !isRequiredSchema(model.schema))*/) {
+        if (rawObj == JSONObject.NULL || (rawObj == null && !isRequiredSchema(model.schema))) {
             return null
         }
         var obj = rawObj as? JSONObject

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/TupleControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/TupleControl.kt
@@ -30,7 +30,7 @@ class TupleControl(override val model: TupleModel, context: EditorContext)
     }
 
     private fun boundValueChanged() {
-        if (model.rawValue == JSONObject.NULL) {
+        if (model.rawValue == JSONObject.NULL || model.rawValue == null) {
             control.displayNull()
         } else {
             control.displayNonNull("[${childControls.size} Element${if (childControls.size == 1) "" else "s"}]")

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/TypeWithChildrenControlHelper.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/TypeWithChildrenControlHelper.kt
@@ -40,7 +40,7 @@ class TypeWithChildrenStatusControl(createLabel: String, onCreate: () -> Unit) :
         styleClass += "type-with-children-label"
     }
 
-    private val button = Button(createLabel).apply {
+    val button = Button(createLabel).apply {
         onAction = EventHandler { onCreate() }
         managedProperty().bind(visibleProperty())
     }

--- a/src/main/kotlin/com/github/hanseter/json/editor/extensions/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/extensions/FilterableTreeItem.kt
@@ -3,6 +3,8 @@ package com.github.hanseter.json.editor.extensions
 import com.github.hanseter.json.editor.actions.ActionsContainer
 import com.github.hanseter.json.editor.controls.TypeControl
 import com.github.hanseter.json.editor.util.DecoratableLabelSkin
+import com.github.hanseter.json.editor.util.ViewOptions
+import com.github.hanseter.json.editor.validators.isRequiredSchema
 import javafx.beans.binding.Bindings
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
@@ -103,6 +105,7 @@ class FilterableTreeItem<T>(value: T) : TreeItem<T>(value) {
  */
 interface TreeItemData {
     val label: Label
+    val title: String
     val control: Node?
     val actions: ActionsContainer?
     val isRoot: Boolean
@@ -114,24 +117,34 @@ interface TreeItemData {
 class ControlTreeItemData(
         val typeControl: TypeControl,
         override val actions: ActionsContainer,
-        val validators: List<com.github.hanseter.json.editor.validators.Validator>) : TreeItemData {
-    override val label = Label(typeControl.model.schema.title).apply {
+        val validators: List<com.github.hanseter.json.editor.validators.Validator>,
+        viewOptions: ViewOptions) : TreeItemData {
+
+    override val title = typeControl.model.schema.title
+
+    override val label = Label(
+            title + if (viewOptions.markRequired && isRequiredSchema(typeControl.model.schema)) " *" else ""
+    ).apply {
         tooltip = typeControl.model.schema.schema.description?.let { Tooltip(it) }
         skin = DecoratableLabelSkin(this)
     }
+
     override val control: Node?
         get() = typeControl.control
 }
 
 object RootTreeItemData : TreeItemData {
-    override val label: Label = Label("root")
+    override val title = "root"
+
+    override val label: Label = Label(title)
+
     override val control: Node?
         get() = null
     override val actions: ActionsContainer?
         get() = null
 }
 
-class SectionRootTreeItemData(title: String) : TreeItemData {
+class SectionRootTreeItemData(override val title: String) : TreeItemData {
     override val label: Label = Label(title)
     override val control: Node?
         get() = null
@@ -141,7 +154,7 @@ class SectionRootTreeItemData(title: String) : TreeItemData {
         get() = true
 }
 
-class HeaderTreeItemData(title: String) : TreeItemData {
+class HeaderTreeItemData(override val title: String) : TreeItemData {
     override val label: Label = Label(title)
     override val control: Node?
         get() = null

--- a/src/main/kotlin/com/github/hanseter/json/editor/types/ModelControlSynchronizer.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/types/ModelControlSynchronizer.kt
@@ -3,6 +3,7 @@ package com.github.hanseter.json.editor.types
 import javafx.beans.property.Property
 import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableValue
+import org.json.JSONObject
 
 class ModelControlSynchronizer<T>(private val controlProp: Property<T>, private val model: TypeModel<T?, *>) : ChangeListener<T?> {
     init {
@@ -15,7 +16,8 @@ class ModelControlSynchronizer<T>(private val controlProp: Property<T>, private 
 
     fun modelChanged() {
         controlProp.removeListener(this)
-        val newVal = model.value ?: model.defaultValue
+        val newVal = model.value
+                ?: (if (model.rawValue == JSONObject.NULL) null else model.defaultValue)
         if (controlProp.value != newVal) {
             controlProp.value = newVal
         }

--- a/src/main/kotlin/com/github/hanseter/json/editor/util/ViewOptions.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/util/ViewOptions.kt
@@ -1,0 +1,8 @@
+package com.github.hanseter.json.editor.util
+
+data class ViewOptions(val markRequired: Boolean = false, val groupBy: PropertyGrouping = PropertyGrouping.REQUIRED)
+
+enum class PropertyGrouping {
+    NONE,
+    REQUIRED
+}

--- a/src/main/kotlin/com/github/hanseter/json/editor/validators/RequiredValidator.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/validators/RequiredValidator.kt
@@ -1,15 +1,19 @@
 package com.github.hanseter.json.editor.validators
 
 import com.github.hanseter.json.editor.actions.TargetSelector
+import com.github.hanseter.json.editor.extensions.SchemaWrapper
 import com.github.hanseter.json.editor.types.TypeModel
 import org.everit.json.schema.ObjectSchema
 
 object RequiredValidator : Validator {
     override val selector: TargetSelector = TargetSelector {
-        true == (it.schema.parent?.schema as? ObjectSchema)?.requiredProperties?.contains(it.schema.getPropertyName())
+        isRequiredSchema(it.schema)
     }
 
     override fun validate(model: TypeModel<*, *>): List<String> =
             if (model.value == null) listOf("Must not be null")
             else emptyList()
 }
+
+fun isRequiredSchema(schema: SchemaWrapper<*>): Boolean =
+        true == (schema.parent?.schema as? ObjectSchema)?.requiredProperties?.contains(schema.getPropertyName())

--- a/src/test/kotlin/com/github/hanseter/json/editor/AllOfTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/AllOfTest.kt
@@ -1,5 +1,6 @@
 package com.github.hanseter.json.editor
 
+import com.github.hanseter.json.editor.controls.TypeWithChildrenStatusControl
 import javafx.scene.control.Spinner
 import javafx.scene.control.TextField
 import javafx.stage.Stage
@@ -57,6 +58,8 @@ class AllOfTest {
         val data = JSONObject()
         editor.display("foo", "foo", data, schema) { it }
         val objectEntry = editor.getItemTable().root.children.first().findChildWithKey("notRoot")!!
+        assertThat(objectEntry.children.size, `is`(0))
+        (objectEntry.value.control as TypeWithChildrenStatusControl).button.fire()
         //3 fields + 1 header
         assertThat(objectEntry.children.size, `is`(4))
         assertThat(objectEntry.findChildWithKey("hello")?.value?.control, `is`(instanceOf(TextField::class.java)))

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -1,5 +1,7 @@
 package com.github.hanseter.json.editor
 
+import com.github.hanseter.json.editor.util.PropertyGrouping
+import com.github.hanseter.json.editor.util.ViewOptions
 import javafx.application.Application
 import javafx.scene.Scene
 import javafx.stage.Stage
@@ -18,8 +20,13 @@ class JsonPropertiesEditorTestApp : Application() {
                     this::class.java.classLoader.getResource("")?.toURI()
         }
 
+        val viewOptions = ViewOptions(
+                markRequired = true,
+                groupBy = PropertyGrouping.NONE
+        )
+
         val propEdit = JsonPropertiesEditor(ReferenceProvider, false, 2,
-                customResolutionScopeProvider)
+                customResolutionScopeProvider, viewOptions)
 //        val testData = JSONObject().put("string", "bla47").put("somethingNotInSchema", "Hello")
 //                .put("string list", listOf("A", "B"))
 //                .put("string_list_readonly", listOf("A", "B"))

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -66,7 +66,7 @@ class JsonPropertiesEditorTestApp : Application() {
 //                "completeValidationTestSchema.json"
 //        "StringSchema.json"
 
-        display(propEdit, "nestedCompositeSchema.json", JSONObject())
+        display(propEdit, "completeValidationTestSchema.json", JSONObject())
 //        displayElementWithOneOf(propEdit)
 
         propEdit.valid.addListener { _, _, new -> println("Is valid: $new") }

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -66,7 +66,7 @@ class JsonPropertiesEditorTestApp : Application() {
 //                "completeValidationTestSchema.json"
 //        "StringSchema.json"
 
-        display(propEdit, "StringSchema.json", JSONObject())
+        display(propEdit, "nestedCompositeSchema.json", JSONObject())
 //        displayElementWithOneOf(propEdit)
 
         propEdit.valid.addListener { _, _, new -> println("Is valid: $new") }

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -3,7 +3,12 @@ package com.github.hanseter.json.editor
 import com.github.hanseter.json.editor.util.PropertyGrouping
 import com.github.hanseter.json.editor.util.ViewOptions
 import javafx.application.Application
+import javafx.scene.Parent
 import javafx.scene.Scene
+import javafx.scene.control.CheckBox
+import javafx.scene.control.ComboBox
+import javafx.scene.layout.HBox
+import javafx.scene.layout.VBox
 import javafx.stage.Stage
 import org.json.JSONObject
 import org.json.JSONTokener
@@ -70,7 +75,7 @@ class JsonPropertiesEditorTestApp : Application() {
 //        displayElementWithOneOf(propEdit)
 
         propEdit.valid.addListener { _, _, new -> println("Is valid: $new") }
-        primaryStage.scene = Scene(propEdit, 800.0, 800.0)
+        primaryStage.scene = Scene(buildUi(propEdit), 800.0, 800.0)
         primaryStage.show()
     }
 
@@ -97,6 +102,35 @@ class JsonPropertiesEditorTestApp : Application() {
             println(it.toString(1))
             it
         }
+    }
+
+    private fun buildUi(propEdit: JsonPropertiesEditor): Parent {
+
+
+        val showStars = CheckBox("Show *")
+
+        val groupBy = ComboBox<PropertyGrouping>().apply {
+            items.addAll(PropertyGrouping.values())
+            selectionModel.select(0)
+        }
+
+        val updateViewOptions = { _: Any? ->
+            val newViewOptions = ViewOptions(showStars.isSelected, groupBy.selectionModel.selectedItem)
+
+            propEdit.updateViewOptions(newViewOptions)
+        }
+
+        showStars.selectedProperty().addListener(updateViewOptions)
+
+        groupBy.selectionModel.selectedItemProperty().addListener(updateViewOptions)
+
+        return VBox(
+                HBox(
+                        showStars,
+                        groupBy
+                ),
+                propEdit
+        )
     }
 
     object ReferenceProvider : IdReferenceProposalProvider {

--- a/src/test/resources/StringSchema.json
+++ b/src/test/resources/StringSchema.json
@@ -3,7 +3,10 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "properties": {
     "string": {
-      "type": ["string","null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "minLength": 3,
       "maxLength": 5,
       "default": "Hello",
@@ -108,6 +111,26 @@
           "type": "number"
         }
       }
+    },
+    "combined object": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "b": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     }
   },
   "required": [

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -201,6 +201,62 @@
           "pattern": "G.+"
         }
       }
+    },
+    "allOfs": {
+      "type": "object",
+      "properties": {
+        "optional": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "b": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "required": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "b": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "required"
+      ]
     }
-  }
+  },
+  "required": [
+    "allOfs",
+    "id-references",
+    "lists",
+    "integers",
+    "numbers",
+    "strings"
+  ]
 }

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -249,14 +249,58 @@
       "required": [
         "required"
       ]
+    },
+    "oneOfs": {
+      "type": "object",
+      "properties": {
+        "optional": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "required": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        }
+      },
+      "required": [
+        "required"
+      ]
+    },
+    "booleans": {
+      "type": "object",
+      "properties": {
+        "optional": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "required"
+      ]
     }
   },
   "required": [
     "allOfs",
+    "oneOfs",
     "id-references",
     "lists",
     "integers",
     "numbers",
-    "strings"
+    "strings",
+    "booleans"
   ]
 }


### PR DESCRIPTION
The main feature of this PR is view options, allowing customization of various aspects of the UI. Currently. the Optional/Required separation can be disabled, and required fields can be marked with an `*`.

In addition, because making a PR per topic is apparently too hard, this contains a fix for fields with a default value being set to `null` explicitly. Previously, when setting them to `null` the default would be displayed as an actual value (not like a placeholder). This was purely visual and had no effect on the data as far as I could tell. The relevant change is in `ModelControlSynchronizer.kt`.

Finally, optional objects/arrays are no longer auto-initialized in the UI if the key is missing in the data, displaying as `null` instead. I think this is better than before to have a little more consistency. But there is still work to be done with objects and arrays, especially if they have default values. Let me know if you think otherwise, then I'll take this out.