### PR TITLE
Make enums support nullability better

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.12</version>
+    <version>0.0.0.13</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/ControlFactory.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ControlFactory.kt
@@ -61,7 +61,15 @@ object ControlFactory {
 
     @Suppress("UNCHECKED_CAST")
     private fun createEnumControl(schema: EffectiveSchema<out Schema>, enumSchema: EnumSchema): TypeControl {
-        val enumModel = EnumModel(schema as EffectiveSchema<Schema>, enumSchema)
+
+        val baseSchema = schema.baseSchema
+        val effectiveSchema: EffectiveSchema<Schema> = if (null in enumSchema.possibleValues) {
+            NullableEffectiveSchema(schema as EffectiveSchema<CombinedSchema>, baseSchema)
+        } else {
+            schema as EffectiveSchema<Schema>
+        }
+
+        val enumModel = EnumModel(effectiveSchema, enumSchema)
         return RowBasedControl<String?>({ EnumControl(enumModel) }, enumModel)
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/ControlFactory.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ControlFactory.kt
@@ -7,10 +7,10 @@ import com.github.hanseter.json.editor.extensions.EffectiveSchemaOfCombination
 import com.github.hanseter.json.editor.extensions.NullableEffectiveSchema
 import com.github.hanseter.json.editor.schemaExtensions.ColorFormat
 import com.github.hanseter.json.editor.schemaExtensions.IdReferenceFormat
+import com.github.hanseter.json.editor.schemaExtensions.synthetic
 import com.github.hanseter.json.editor.types.*
 import com.github.hanseter.json.editor.util.EditorContext
 import org.everit.json.schema.*
-import java.lang.reflect.Method
 
 
 object ControlFactory {
@@ -82,7 +82,7 @@ object ControlFactory {
             }
 
     private fun createAllOfControl(schema: EffectiveSchema<CombinedSchema>, context: EditorContext): TypeControl {
-        if (isSynthetic(schema.baseSchema)) {
+        if (schema.baseSchema.synthetic) {
             return createControlFromSyntheticAllOf(schema)
         }
 
@@ -114,10 +114,6 @@ object ControlFactory {
         }
         return UnsupportedTypeControl(UnsupportedTypeModel(schema))
     }
-
-    private val isSyntheticMethod: Method = CombinedSchema::class.java.getDeclaredMethod("isSynthetic").apply { isAccessible = true }
-    private fun isSynthetic(combinedSchema: CombinedSchema): Boolean =
-            isSyntheticMethod.invoke(combinedSchema) as Boolean
 
 }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/actions/TargetSelector.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/actions/TargetSelector.kt
@@ -57,7 +57,18 @@ fun interface TargetSelector {
     object Required : TargetSelector {
 
         override fun matches(model: TypeModel<*, *>): Boolean {
-            val schema = model.schema.parent?.baseSchema?.let { getReferredSchema(it) }
+            /*
+             this differs from schema.required in that this returns true if the actual status cannot
+             be determined while schema.required returns false.
+
+             Many custom actions expect it to be true in those cases, so this method should not
+             simply be reduced to querying schema.required.
+
+             It may be prudent to make this selector configurable so the API user can decide whether
+             they want it to apply strictly or leniently.
+             */
+
+            val schema = model.schema.nonSyntheticAncestor?.baseSchema?.let { getReferredSchema(it) }
 
             return (schema as? ObjectSchema)?.let {
                 model.schema.propertyName in it.requiredProperties

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/EnumControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/EnumControl.kt
@@ -6,6 +6,7 @@ import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableValue
 import org.controlsfx.control.SearchableComboBox
+import org.json.JSONObject
 
 //TODO this control makes every enum a string, even if it is something else. This needs to be improved.
 class EnumControl(private val model: EnumModel) : ControlWithProperty<String?>, ChangeListener<String?> {
@@ -35,11 +36,13 @@ class EnumControl(private val model: EnumModel) : ControlWithProperty<String?>, 
     }
 
     private fun setSelectedValue(value: String?) {
-        if (control.items.contains(value)) {
-            control.selectionModel.select(value)
-        } else {
-            control.selectionModel.select(model.defaultValue)
-        }
+        control.selectionModel.select(
+                when {
+                    control.items.contains(value) -> value
+                    model.rawValue == JSONObject.NULL -> null
+                    else -> model.defaultValue
+                }
+        )
     }
 
 }

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/EnumControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/EnumControl.kt
@@ -14,12 +14,12 @@ class EnumControl(private val model: EnumModel) : ControlWithProperty<String?>, 
 
     init {
         control.minWidth = 150.0
-        control.items.setAll(model.enumSchema.possibleValuesAsList.map { it.toString() })
+        control.items.setAll(model.enumSchema.possibleValuesAsList.filterNotNull().map { it.toString() })
         control.selectionModel.selectedIndexProperty()
                 .addListener { _, _, new ->
                     if (new.toInt() >= 0) {
                         property.removeListener(this)
-                        property.value = model.enumSchema.possibleValuesAsList[new.toInt()].toString()
+                        property.value = model.enumSchema.possibleValuesAsList.filterNotNull()[new.toInt()].toString()
                         property.addListener(this)
                     }
                 }

--- a/src/main/kotlin/com/github/hanseter/json/editor/extensions/EffectiveSchema.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/extensions/EffectiveSchema.kt
@@ -1,5 +1,7 @@
 package com.github.hanseter.json.editor.extensions
 
+import com.github.hanseter.json.editor.schemaExtensions.synthetic
+import org.everit.json.schema.CombinedSchema
 import org.everit.json.schema.JSONPointer
 import org.everit.json.schema.ObjectSchema
 import org.everit.json.schema.Schema
@@ -23,7 +25,7 @@ interface EffectiveSchema<T : Schema> {
         get() = parent?.pointer?.let { it + propertyName } ?: emptyList()
 
     val required: Boolean
-        get() = true == (parent?.baseSchema as? ObjectSchema)?.requiredProperties?.contains(propertyName)
+        get() = true == (nonSyntheticAncestor?.baseSchema as? ObjectSchema)?.requiredProperties?.contains(propertyName)
 
     val propertyName: String
 
@@ -34,4 +36,18 @@ interface EffectiveSchema<T : Schema> {
 
     fun extractProperty(json: JSONObject): Any? =
             JSONPointer(pointer).queryFrom(json)
+
+    /**
+     * Gets the closest non-synthetic ancestor.
+     */
+    val nonSyntheticAncestor: EffectiveSchema<*>?
+        get() {
+            val baseSchema = parent?.baseSchema
+
+            if (baseSchema is CombinedSchema && baseSchema.synthetic) {
+                return parent?.nonSyntheticAncestor
+            }
+
+            return parent
+        }
 }

--- a/src/main/kotlin/com/github/hanseter/json/editor/schemaExtensions/Extensions.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/schemaExtensions/Extensions.kt
@@ -1,0 +1,9 @@
+package com.github.hanseter.json.editor.schemaExtensions
+
+import org.everit.json.schema.CombinedSchema
+import java.lang.reflect.Method
+
+private val isSyntheticMethod: Method = CombinedSchema::class.java.getDeclaredMethod("isSynthetic").apply { isAccessible = true }
+
+val CombinedSchema.synthetic: Boolean
+    get() = isSyntheticMethod.invoke(this) as Boolean

--- a/src/test/kotlin/com/github/hanseter/json/editor/EnumTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/EnumTest.kt
@@ -1,0 +1,166 @@
+package com.github.hanseter.json.editor
+
+import javafx.scene.control.Button
+import javafx.scene.control.ComboBox
+import javafx.stage.Stage
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.testfx.framework.junit5.ApplicationExtension
+import org.testfx.framework.junit5.Start
+
+@ExtendWith(ApplicationExtension::class)
+class EnumTest {
+
+    lateinit var editor: JsonPropertiesEditor
+
+    @Start
+    fun start(stage: Stage) {
+        editor = JsonPropertiesEditor()
+    }
+
+    @Test
+    fun optionalEnumHasResetToDefault() {
+        val schema = JSONObject("""
+{
+  "type":"object",
+  "properties": {
+    "e": {
+      "type":"string",
+      "enum": ["foo", "bar"]
+    }
+  }
+}""")
+        editor.display("1", "1", JSONObject(), schema) { it }
+        val itemTable = editor.getItemTable()
+        val enumEntry = itemTable.root.children[0].findChildWithKey("e")!!
+        assertThat(enumEntry.value.createActions()!!.children, Matchers.hasSize(1))
+        assertThat((enumEntry.value.createActions()!!.children[0] as Button).text, Matchers.`is`("↻"))
+    }
+
+    @Test
+    fun optionalDefaultEnumHasResetToDefault() {
+        val schema = JSONObject("""
+{
+  "type":"object",
+  "properties": {
+    "e": {
+      "type":"string",
+      "enum": ["foo", "bar"],
+      "default": "bar"
+    }
+  }
+}""")
+        editor.display("1", "1", JSONObject(), schema) { it }
+        val itemTable = editor.getItemTable()
+        val enumEntry = itemTable.root.children[0].findChildWithKey("e")!!
+        assertThat(enumEntry.value.createActions()!!.children, Matchers.hasSize(1))
+        assertThat((enumEntry.value.createActions()!!.children[0] as Button).text, Matchers.`is`("↻"))
+    }
+
+    @Test
+    fun requiredEnumHasNoResetToDefault() {
+        val schema = JSONObject("""
+{
+  "type":"object",
+  "properties": {
+    "e": {
+      "type":"string",
+      "enum": ["foo", "bar"]
+    }
+  },
+  "required": ["e"]
+}""")
+        editor.display("1", "1", JSONObject(), schema) { it }
+        val itemTable = editor.getItemTable()
+        val enumEntry = itemTable.root.children[0].findChildWithKey("e")!!
+
+        assertThat(enumEntry.value.createActions()!!.children, Matchers.emptyIterable())
+    }
+
+    @Test
+    fun nullableEnumHasAllActions() {
+        val schema = JSONObject("""
+{
+  "type":"object",
+  "properties": {
+    "e": {
+      "type": ["string", "null"],
+      "enum": ["foo", "bar", null],
+      "default": "bar"
+    }
+  }
+}""")
+        editor.display("1", "1", JSONObject(), schema) { it }
+        val itemTable = editor.getItemTable()
+        val enumEntry = itemTable.root.children[0].findChildWithKey("e")!!
+
+        assertThat(enumEntry.value.createActions()!!.children, Matchers.hasSize(2))
+        assertThat((enumEntry.value.createActions()!!.children[0] as Button).text, Matchers.`is`("↻"))
+        assertThat((enumEntry.value.createActions()!!.children[1] as Button).text, Matchers.`is`("Ø"))
+    }
+
+    @Test
+    fun nullableEnumHasCorrectComboBox() {
+        val schema = JSONObject("""
+{
+  "type":"object",
+  "properties": {
+    "e": {
+      "enum": ["foo", "bar", null]
+    }
+  }
+}""")
+        editor.display("1", "1", JSONObject(), schema) { it }
+        val itemTable = editor.getItemTable()
+        val enumEntry = itemTable.root.children[0].findChildWithKey("e")!!
+
+        val control = enumEntry.value.createControl()!!.control as ComboBox<*>
+
+        assertThat(control.items, Matchers.containsInAnyOrder("foo", "bar"))
+    }
+
+    @Test
+    fun nullableEnumButtonsWork() {
+        val schema = JSONObject("""
+{
+  "type":"object",
+  "properties": {
+    "e": {
+      "type": ["string", "null"],
+      "enum": ["foo", "bar", null],
+      "default": "bar"
+    }
+  }
+}""")
+        val data = JSONObject("""{"e": "foo"}""")
+
+        editor.display("1", "1", data, schema) { it }
+        val itemTable = editor.getItemTable()
+        val enumEntry = itemTable.root.children[0].findChildWithKey("e")!!
+
+        val control = enumEntry.value.createControl()
+        val comboBox = control!!.control as ComboBox<*>
+
+        val defaultButton = enumEntry.value.createActions()!!.children[0] as Button
+        val nullButton = enumEntry.value.createActions()!!.children[1] as Button
+
+        defaultButton.fire()
+
+        control.updateDisplayedValue()
+
+        assertThat(data.has("e"), Matchers.`is`(false))
+        assertThat(comboBox.value, Matchers.`is`("bar"))
+        assertThat(comboBox.styleClass, Matchers.hasItem("has-default-value"))
+
+        nullButton.fire()
+
+        control.updateDisplayedValue()
+
+        assertThat(data.opt("e"), Matchers.`is`(JSONObject.NULL))
+        assertThat(comboBox.value, Matchers.nullValue())
+    }
+
+}

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -8,6 +8,12 @@
         "req": {
           "type": "string"
         },
+        "nullable": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "minLength": {
           "type": "string",
           "minLength": 3
@@ -291,6 +297,63 @@
       "required": [
         "required"
       ]
+    },
+    "enums": {
+      "type": "object",
+      "properties": {
+        "required": {
+          "type": "string",
+          "enum": [
+            "foo",
+            "bar",
+            "baz"
+          ]
+        },
+        "optional": {
+          "type": "string",
+          "enum": [
+            "foo",
+            "bar",
+            "baz"
+          ]
+        },
+        "default": {
+          "type": "string",
+          "enum": [
+            "foo",
+            "bar",
+            "baz"
+          ],
+          "default": "bar"
+        },
+        "nullable": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "foo",
+            "bar",
+            "baz",
+            null
+          ]
+        },
+        "nullableDefault": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "foo",
+            "bar",
+            "baz"
+          ],
+          "default": "bar"
+        }
+      },
+      "required": [
+        "required"
+      ]
     }
   },
   "required": [
@@ -301,11 +364,13 @@
     "integers",
     "numbers",
     "strings",
-    "booleans"
+    "booleans",
+    "enums"
   ],
   "order": [
     "booleans",
     "allOfs",
+    "enums",
     "id-references",
     "integers",
     "lists",

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -346,7 +346,8 @@
           "enum": [
             "foo",
             "bar",
-            "baz"
+            "baz",
+            null
           ],
           "default": "bar"
         }


### PR DESCRIPTION
There were some issues with enums, `null` values, and required/optional, fixed in this MR.

- To comply with the spec, `null` must be added to a schema's `enum` array. This used to throw an exception.
- It was impossible to specify that an enum property is explicitly nullable. This now works, but it is not based on the `type` containing `"null"`, but instead on the `enum` array containing `null`, since with enums, specifying the `type` is optional, and the `enum` entry is required anyway.
- Some enums were not correctly registered as non-required, so the "Reset to Default" action didn't appear for them.

A test for enums was added to hopefully prevent regressions for these issues.