### PR TITLE
Various small bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.17</version>
+    <version>0.0.0.18</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/extensions/NullableEffectiveSchema.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/extensions/NullableEffectiveSchema.kt
@@ -20,4 +20,9 @@ class NullableEffectiveSchema<T : Schema>(override val parent: EffectiveSchema<C
     override val propertyName: String
         get() = parent.propertyName
 
+    override val cssClasses: List<String>
+        get() = super.cssClasses + parent.cssClasses
+
+    override val cssStyle: String?
+        get() = super.cssStyle ?: parent.cssStyle
 }

--- a/src/test/kotlin/com/github/hanseter/json/editor/AllOfTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/AllOfTest.kt
@@ -47,7 +47,8 @@ class AllOfTest {
     fun compositeSchemaNotInRoot() {
         val schema = JSONObject("""{"type":"object","properties":{"notRoot":{"allOf": [
             {
-      "${'$'}ref": "ReferencedPointSchema.json"
+      "${'$'}ref": "ReferencedPointSchema.json",
+      "title": "notRoot"
     },{
       "type": "object",
       "properties": {

--- a/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
@@ -293,12 +293,23 @@ class SchemaNormalizationTest {
     },
     "b": {
       "${'$'}ref": "#/definitions/a"
+    },
+    "c": {
+      "type": "object",
+      "properties": {
+        "a": {
+          "${'$'}ref": "#/definitions/b"
+        }
+      }
     }
   },
   "type": "object",
   "properties": {
     "foo": {
       "${'$'}ref": "#/definitions/b"
+    },
+    "bar": {
+      "${'$'}ref": "#/definitions/c"
     }
   }
 }
@@ -306,5 +317,7 @@ class SchemaNormalizationTest {
         val result = SchemaNormalizer.resolveRefs(schema, null)
 
         assertThat(result.query("#/properties/foo/type"), `is`("integer"))
+
+        assertThat(result.query("#/properties/bar/properties/a/type"), `is`("integer"))
     }
 }


### PR DESCRIPTION
When the target of an internal `$ref`, i.e. one that points to a fragment in the current file, not a different one, itself contained a `$ref` that second `$ref` would be resolved using the wrong scope, which would fail. This also affected cases where the second `$ref` was inside a subproperty, such as 

```json
{
  "definitions": {
    "int": { "type": "integer" },
    "obj": {
      "properties": { "a": { "$ref": "#/definitions/int" } }
    }
  },
  "properties": {
    "o": { "$ref": "#/definitions/obj" }
  }
}
```

Attempting to resolve such as schema would cause a `JSONException`.

In addition, the `style` and `styleClass` properties were ignored in explicitly nullable properties.