### PR TITLE
Add enum descriptions, better error bubbles, and improved $ref resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.20</version>
+    <version>0.0.0.21</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>
@@ -65,12 +65,14 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <configuration><instructions>
-                    <Include-Resource>
-                        META-INF/${artifactId}.kotlin_module=target/classes/META-INF/${artifactId}.kotlin_module,
-                        {maven-resources}
-                    </Include-Resource>
-                </instructions></configuration>
+                <configuration>
+                    <instructions>
+                        <Include-Resource>
+                            META-INF/${artifactId}.kotlin_module=target/classes/META-INF/${artifactId}.kotlin_module,
+                            {maven-resources}
+                        </Include-Resource>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
@@ -222,7 +222,7 @@ object SchemaNormalizer {
         if (resolutionScope != null) {
             try {
                 val fullUri = resolve(resolutionScope, url)
-                return ResolvedSchema(get(resolve(resolutionScope, url)), fullUri)
+                return ResolvedSchema(get(resolve(resolutionScope, url)), fullUri.resolve("."))
             } catch (e: IOException) {
                 //ignore exception
             }

--- a/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
@@ -212,6 +212,9 @@ object SchemaNormalizer {
 
     private fun resolveRefFromUrl(url: String, resolutionScope: URI?): ResolvedSchema {
         fun get(uri: URI): InputStream {
+            if (!uri.isAbsolute) {
+                throw IllegalArgumentException("""URI is not absolute: $uri""")
+            }
             val conn = uri.toURL().openConnection()
             val location = conn.getHeaderField("Location")
             return location?.let { get(URI(it)) } ?: conn.content as InputStream

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/DoubleControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/DoubleControl.kt
@@ -9,10 +9,6 @@ import java.text.DecimalFormat
 import java.text.ParsePosition
 
 class DoubleControl(schema: NumberSchema) : ControlWithProperty<Double?> {
-    private val minInclusive = schema.minimum?.toDouble() ?: -Double.MAX_VALUE
-    private val minExclusive = schema.exclusiveMinimumLimit?.toDouble() ?: -Double.MAX_VALUE
-    private val maxInclusive = schema.maximum?.toDouble() ?: Double.MAX_VALUE
-    private val maxExclusive = schema.exclusiveMaximumLimit?.toDouble() ?: Double.MAX_VALUE
 
     private val converter = StringDoubleConverter()
 
@@ -64,7 +60,6 @@ class DoubleControl(schema: NumberSchema) : ControlWithProperty<Double?> {
             if (value != null) {
                 inner.value = value
                 inner.decrement(steps)
-                coerceValue()
                 value = inner.value
             }
         }
@@ -73,23 +68,7 @@ class DoubleControl(schema: NumberSchema) : ControlWithProperty<Double?> {
             if (value != null) {
                 inner.value = value
                 inner.increment(steps)
-                coerceValue()
                 value = inner.value
-            }
-        }
-
-        private fun coerceValue() {
-            if (inner.value > maxInclusive) {
-                inner.value = maxInclusive
-            }
-            if (inner.value >= maxExclusive) {
-                inner.value = maxExclusive - 1
-            }
-            if (inner.value < minInclusive) {
-                inner.value = minInclusive
-            }
-            if (inner.value < minExclusive) {
-                inner.value = minExclusive + 1
             }
         }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/IntegerControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/IntegerControl.kt
@@ -7,13 +7,7 @@ import javafx.util.converter.IntegerStringConverter
 import org.everit.json.schema.NumberSchema
 
 class IntegerControl(schema: NumberSchema) : ControlWithProperty<Int?> {
-    override val control = Spinner<Int>(IntegerSpinnerValueFactoryNullSafe(
-            schema.minimum?.toInt()
-                    ?: (schema.exclusiveMinimumLimit?.toInt()?.inc())
-                    ?: Int.MIN_VALUE,
-            schema.maximum?.toInt()
-                    ?: (schema.exclusiveMaximumLimit?.toInt()?.dec())
-                    ?: Int.MAX_VALUE))
+    override val control = Spinner<Int>(IntegerSpinnerValueFactoryNullSafe())
     override val property: Property<Int?>
         get() = control.valueFactory.valueProperty()
 
@@ -37,19 +31,9 @@ class IntegerControl(schema: NumberSchema) : ControlWithProperty<Int?> {
         }
     }
 
-    class IntegerSpinnerValueFactoryNullSafe(min: Int, max: Int) : SpinnerValueFactory<Int?>() {
+    class IntegerSpinnerValueFactoryNullSafe() : SpinnerValueFactory<Int?>() {
         init {
             converter = IntegerStringConverter()
-
-            valueProperty().addListener { _, _, newValue: Int? ->
-                if (newValue != null) {
-                    if (newValue < min) {
-                        value = min
-                    } else if (newValue > max) {
-                        value = max
-                    }
-                }
-            }
         }
 
         override fun increment(steps: Int) {

--- a/src/main/kotlin/com/github/hanseter/json/editor/types/EnumModel.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/types/EnumModel.kt
@@ -17,4 +17,19 @@ class EnumModel(override val schema: EffectiveSchema<Schema>, val enumSchema: En
         set(value) {
             bound?.setValue(schema, value)
         }
+
+    val enumDescriptions: Map<String, String?>
+        get() {
+            val descList = ((
+                    enumSchema.unprocessedProperties["enumDescriptions"]
+                            ?: schema.baseSchema.unprocessedProperties["enumDescriptions"]) as? List<*>
+                    )?.filterIsInstance<String>()
+
+            return enumSchema.possibleValuesAsList
+                    .filterIsInstance<String>()
+                    .withIndex()
+                    .associateBy({ it.value }) {
+                        descList?.getOrNull(it.index)
+                    }
+        }
 }

--- a/src/main/resources/com/github/hanseter/json/editor/TreeTableView.css
+++ b/src/main/resources/com/github/hanseter/json/editor/TreeTableView.css
@@ -47,7 +47,17 @@
     -fx-fill: -fx-text-base-color;
 }
 
+.combo-box .enum-desc-label {
+    -fx-font-style: italic;
+    -fx-opacity: 70%;
+}
+
+.combo-box > .list-cell > .enum-desc-label {
+    -fx-text-fill: -fx-text-base-color;
+}
+
 .combo-box.has-null-value > .list-cell, .combo-box.has-default-value > .list-cell,
+.combo-box.has-null-value > .list-cell > .enum-desc-label, .combo-box.has-default-value > .list-cell > .enum-desc-label,
 .color-picker.has-null-value > .label, .color-picker.has-default-value > .label {
     -fx-text-fill: derive(-fx-control-inner-background, -45%);
 }

--- a/src/test/kotlin/com/github/hanseter/json/editor/NumberTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/NumberTest.kt
@@ -64,10 +64,10 @@ class NumberTest {
 
     @ParameterizedTest
     @CsvSource(
-            "false, 42.5,  1, 43",
-            "false, 42.5, -2, 41",
-            "true,    42,  5, 43",
-            "true,    42, -5, 41"
+            "false, 42.5,  1, 43.5",
+            "false, 42.5, -2, 40.5",
+            "true,    42,  5, 47",
+            "true,    42, -5, 37"
     )
     fun modifyValueBySpinnerInRange(requireInt: Boolean, initialValue: Double, step: Int, result: Double) {
         val schema = JSONObject("""{"type":"object","properties":{"num":{"type":"number",
@@ -79,9 +79,11 @@ class NumberTest {
         editor.display("1", "1", data, schema) { it }
         val itemTable = editor.getItemTable()
         val numberControl = editor.getControlInTable("num") as Spinner<Number>
+        MatcherAssert.assertThat(editor.valid.get(), `is`(true))
         numberControl.increment(step)
         val converted = numberControl.valueFactory.converter.toString(result)
         MatcherAssert.assertThat(numberControl.editor.text, `is`(converted))
+        MatcherAssert.assertThat(editor.valid.get(), `is`(false))
     }
 
     @Test

--- a/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
@@ -283,6 +283,29 @@ class SchemaNormalizationTest {
     }
 
     @Test
+    fun testRefToDifferentDir() {
+        val uri = this::class.java.classLoader.getResource("")?.toURI()
+
+        val schema = JSONObject(
+                """
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "${'$'}ref": "./subdir/firstSchema.json"
+    }
+  }
+}
+""")
+
+        val result = SchemaNormalizer.resolveRefs(schema, uri)
+
+        assertThat(result.query("#/properties/foo/type"), `is`("object"))
+
+        assertThat(result.query("#/properties/foo/properties/nestedRef/type"), `is`("string"))
+    }
+
+    @Test
     fun testRefInsideDefinitions() {
         val schema = JSONObject(
                 """

--- a/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
@@ -306,6 +306,25 @@ class SchemaNormalizationTest {
     }
 
     @Test
+    fun testRefToFragmentInDifferentFile() {
+        val uri = this::class.java.classLoader.getResource("")?.toURI()
+
+        val schema = JSONObject("""
+            {
+              "properties": {
+                "a": {
+                  "${'$'}ref": "TestSchema2.json#/properties/name"
+                }
+              }
+            }
+        """.trimIndent())
+
+        val result = SchemaNormalizer.resolveRefs(schema, uri)
+
+        assertThat(result.query("#/properties/a/type"), `is`("string"))
+    }
+
+    @Test
     fun testRefInsideDefinitions() {
         val schema = JSONObject(
                 """

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -396,6 +396,35 @@
             null
           ],
           "default": "bar"
+        },
+        "withDesc": {
+          "type": "string",
+          "enum": [
+            "foo",
+            "bar",
+            "baz"
+          ],
+          "enumDescriptions": [
+            "the fooest of them all",
+            "the barest of them all",
+            "the bazest of them all"
+          ],
+          "default": "baz"
+        },
+        "withDescRo": {
+          "type": "string",
+          "enum": [
+            "foo",
+            "bar",
+            "baz"
+          ],
+          "enumDescriptions": [
+            "the fooest of them all",
+            "the barest of them all",
+            "the bazest of them all"
+          ],
+          "default": "baz",
+          "readOnly": true
         }
       },
       "required": [

--- a/src/test/resources/subdir/firstSchema.json
+++ b/src/test/resources/subdir/firstSchema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "nestedRef": {
+      "$ref": "./secondSchema.json"
+    }
+  }
+}

--- a/src/test/resources/subdir/secondSchema.json
+++ b/src/test/resources/subdir/secondSchema.json
@@ -1,0 +1,3 @@
+{
+  "type": "string"
+}


### PR DESCRIPTION
This PR adds optional descriptions for enums. If an enum schema contains an `enumDescriptions` array, the items of that array are interpreted as descriptions for enum items and displayed after the item itself.

It also adds error bubbles to missing required keys. Previously, the error would only be shown at the parent element, which can be confusing. Now it is shown at the parent and the missing key itself.

Finally, it changes the `$ref` resolution so that `$ref`s are resolved relative to the document they are defined in, rather than to the root document.

### Example for the `$ref` change

#### `rootSchema.json`
```jsonc
{
  "type": "object",
  "properties": {
    "a": {
      "$ref": "./subdir/a.json"
    }
  }
}
```

#### `subdir/a.json`
```jsonc
{
  "type": "object",
  "properties": {
    "b": {
      "$ref" /* old */: "./subdir/b.json" // even though a and b are in the same directory
      "$ref" /* new */: "./b.json"
    }
  }
}
```

#### `subdir/b.json`
```jsonc
{
  "type": "string"
}
```