### PR TITLE
Add better support for discriminated unions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.0.26</version>
+    <version>0.0.0.27</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -6,7 +6,6 @@ import com.github.hanseter.json.editor.controls.ObjectControl
 import com.github.hanseter.json.editor.controls.TupleControl
 import com.github.hanseter.json.editor.controls.TypeControl
 import com.github.hanseter.json.editor.extensions.SimpleEffectiveSchema
-import com.github.hanseter.json.editor.types.TypeModel
 import com.github.hanseter.json.editor.ui.*
 import com.github.hanseter.json.editor.util.EditorContext
 import com.github.hanseter.json.editor.util.PropertyGrouping
@@ -19,7 +18,6 @@ import javafx.beans.property.SimpleBooleanProperty
 import javafx.event.Event
 import org.json.JSONObject
 import java.net.URI
-import java.util.function.Predicate
 import java.util.function.Supplier
 
 class JsonPropertiesPane(
@@ -196,21 +194,8 @@ class JsonPropertiesPane(
 
     private fun updateTreeAfterChildChange(control: TypeControl) {
         val item = findInTree(treeItem, control) ?: return
-        val iterNewChilds = control.childControls.listIterator()
-        val iterOldChilds = item.list.listIterator()
-        while (iterNewChilds.hasNext() && iterOldChilds.hasNext()) {
-            val newChild = iterNewChilds.next()
-            val oldChild = iterOldChilds.next()
-            if (newChild::class != oldChild::class) {
-                iterOldChilds.set(wrapControlInTreeItem(newChild))
-            }
-        }
-        iterNewChilds.forEachRemaining {
-            iterOldChilds.add(wrapControlInTreeItem(it))
-        }
-        while (iterOldChilds.hasNext()) {
-            iterOldChilds.remove()
-        }
+
+        item.list.setAll(control.childControls.map { wrapControlInTreeItem(it) })
     }
 
     private fun findInTree(

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ConstControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ConstControl.kt
@@ -1,0 +1,25 @@
+package com.github.hanseter.json.editor.controls
+
+import javafx.beans.binding.Bindings
+import javafx.beans.property.Property
+import javafx.beans.property.SimpleObjectProperty
+import javafx.scene.control.Label
+
+class ConstControl : ControlWithProperty<Any?> {
+
+    override val property: Property<Any?> = SimpleObjectProperty(null)
+
+    override val control = Label("Const value").apply {
+        textProperty().bind(
+            Bindings.createStringBinding(
+                { property.value?.toString() ?: "null" },
+                property
+            )
+        )
+    }
+
+
+    override fun previewNull(b: Boolean) {
+        property.value = null
+    }
+}

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/OneOfControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/OneOfControl.kt
@@ -15,9 +15,10 @@ class OneOfControl(override val model: OneOfModel) : TypeControl {
 
     override fun bindTo(type: BindableJsonType) {
         val child = model.actualType
+        val grandChildren = child?.childControls?.toList().orEmpty()
         model.bound = type
         val newChild = model.actualType
-        if (newChild !== child) {
+        if (newChild !== child || newChild?.childControls.orEmpty() != grandChildren) {
             model.editorContext.childrenChangedCallback(this)
         }
     }
@@ -25,10 +26,11 @@ class OneOfControl(override val model: OneOfModel) : TypeControl {
     override fun createLazyControl(): LazyControl = OneOfLazyControl()
 
     private inner class OneOfLazyControl : LazyControl {
-        private val selectionListener: ChangeListener<Schema?> = ChangeListener<Schema?> { _, _, selected ->
-            model.selectType(selected)
-            model.editorContext.childrenChangedCallback(this@OneOfControl)
-        }
+        private val selectionListener: ChangeListener<Schema?> =
+            ChangeListener<Schema?> { _, _, selected ->
+                model.selectType(selected)
+                model.editorContext.childrenChangedCallback(this@OneOfControl)
+            }
         override val control: ComboBox<Schema> = ComboBox<Schema>().apply {
             items.addAll(model.schema.baseSchema.subschemas)
             converter = SchemaTitleStringConverter
@@ -47,7 +49,7 @@ class OneOfControl(override val model: OneOfModel) : TypeControl {
 
     private object SchemaTitleStringConverter : StringConverter<Schema>() {
         override fun toString(obj: Schema?): String? =
-                obj?.let { SimpleEffectiveSchema.calcSchemaTitle(it) }
+            obj?.let { SimpleEffectiveSchema.calcSchemaTitle(it) }
 
         override fun fromString(string: String?): Schema? = null
     }

--- a/src/main/kotlin/com/github/hanseter/json/editor/extensions/ForceReadOnlyEffectiveSchema.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/extensions/ForceReadOnlyEffectiveSchema.kt
@@ -1,0 +1,13 @@
+package com.github.hanseter.json.editor.extensions
+
+import org.everit.json.schema.Schema
+
+
+class ForceReadOnlyEffectiveSchema<T : Schema>(
+    private val actual: EffectiveSchema<T>
+) : EffectiveSchema<T> by actual {
+
+    override val readOnly: Boolean
+        get() = true
+
+}

--- a/src/main/kotlin/com/github/hanseter/json/editor/types/DiscriminatedOneOfModel.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/types/DiscriminatedOneOfModel.kt
@@ -58,18 +58,24 @@ class DiscriminatedOneOfModel(
 
     companion object {
         fun getDiscriminatorSchema(schema: Schema, key: String): ConstSchema? {
-            val subSchema = (schema as? ObjectSchema)?.propertySchemas?.get(key)
+            val objectSchema = schema as? ObjectSchema ?: return null
 
-            if (subSchema is ConstSchema) {
-                return subSchema
+            if (key !in objectSchema.requiredProperties) {
+                return null
             }
-            if (subSchema is CombinedSchema && subSchema.criterion == CombinedSchema.ALL_CRITERION && subSchema.synthetic) {
-                return subSchema.subschemas.firstNotNullOf {
-                    it as? ConstSchema
+
+            val subSchema = objectSchema.propertySchemas[key]
+
+            return when {
+                subSchema is ConstSchema -> subSchema
+                subSchema is CombinedSchema && subSchema.criterion == CombinedSchema.ALL_CRITERION && subSchema.synthetic -> {
+                    subSchema.subschemas.firstNotNullOf {
+                        it as? ConstSchema
+                    }
                 }
+                else -> null
             }
 
-            return null
         }
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/types/DiscriminatedOneOfModel.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/types/DiscriminatedOneOfModel.kt
@@ -1,0 +1,69 @@
+package com.github.hanseter.json.editor.types
+
+import com.github.hanseter.json.editor.controls.TypeControl
+import com.github.hanseter.json.editor.extensions.EffectiveSchema
+import com.github.hanseter.json.editor.schemaExtensions.synthetic
+import com.github.hanseter.json.editor.util.EditorContext
+import org.everit.json.schema.CombinedSchema
+import org.everit.json.schema.ConstSchema
+import org.everit.json.schema.ObjectSchema
+import org.everit.json.schema.Schema
+import org.json.JSONObject
+
+/**
+ * A variant oneOf model to provide enhanced support for discriminated unions.
+ */
+class DiscriminatedOneOfModel(
+    schema: EffectiveSchema<CombinedSchema>,
+    editorContext: EditorContext,
+    val discriminatorKey: String
+) : OneOfModel(schema, editorContext) {
+
+    override fun tryGuessActualType(): TypeControl? {
+        val data = value as? JSONObject ?: return null
+        val discriminatorValue = data.opt(discriminatorKey) ?: return null
+
+        return schema.baseSchema.subschemas.find {
+            val discSchema = getDiscriminatorSchema(it) ?: return@find false
+
+            discSchema.permittedValue == discriminatorValue
+        }?.let {
+            createActualControl(it)
+        }
+    }
+
+    override fun produceValueForNewType(
+        schema: ObjectSchema,
+        keysToRemove: Set<String>,
+        keysToKeep: Set<String>
+    ): JSONObject? {
+        return super.produceValueForNewType(schema, keysToRemove, keysToKeep)?.apply {
+            val discriminatorValue = getDiscriminatorSchema(schema)?.permittedValue
+
+            put(discriminatorKey, discriminatorValue)
+        }
+    }
+
+    private fun getDiscriminatorSchema(schema: Schema): ConstSchema? {
+        return Companion.getDiscriminatorSchema(schema, discriminatorKey)
+    }
+
+    companion object {
+        fun getDiscriminatorSchema(schema: Schema, key: String): ConstSchema? {
+            val subSchema = (schema as? ObjectSchema)?.propertySchemas?.get(key)
+
+            if (subSchema is ConstSchema) {
+                return subSchema
+            }
+            if (subSchema is CombinedSchema && subSchema.criterion == CombinedSchema.ALL_CRITERION && subSchema.synthetic) {
+                return subSchema.subschemas.firstNotNullOf {
+                    it as? ConstSchema
+                }
+            }
+
+            return null
+        }
+    }
+
+
+}

--- a/src/main/kotlin/com/github/hanseter/json/editor/types/DiscriminatedOneOfModel.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/types/DiscriminatedOneOfModel.kt
@@ -44,6 +44,14 @@ class DiscriminatedOneOfModel(
         }
     }
 
+    override fun isValid(schema: Schema, data: Any): Boolean {
+        val descSchema = getDiscriminatorSchema(schema) ?: return false
+
+        val descValue = (data as? JSONObject)?.opt(discriminatorKey) ?: return false
+
+        return descSchema.permittedValue == descValue
+    }
+
     private fun getDiscriminatorSchema(schema: Schema): ConstSchema? {
         return Companion.getDiscriminatorSchema(schema, discriminatorKey)
     }

--- a/src/main/kotlin/com/github/hanseter/json/editor/types/OneOfModel.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/types/OneOfModel.kt
@@ -35,7 +35,7 @@ open class OneOfModel(
         }
 
     var actualType: TypeControl? = null
-        protected set
+        private set
 
     val objectOptionData = JSONObject()
 //    val optionData = HashMap<Schema, Any>()
@@ -55,7 +55,7 @@ open class OneOfModel(
         }
     }
 
-    private fun isValid(schema: Schema, data: Any): Boolean =
+    protected open fun isValid(schema: Schema, data: Any): Boolean =
         try {
             schema.validate(data)
             true

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
@@ -175,11 +175,11 @@ class StyledTreeItemData(override val title: String, override val cssClasses: Li
     override fun createActions(): ActionsContainer? = null
 
     override fun registerChangeListener(listener: (TreeItemData) -> Unit) {
-        changeListeners.forEach { it(this) }
+        changeListeners.add(listener)
     }
 
     override fun removeChangeListener(listener: (TreeItemData) -> Unit) {
-        changeListeners.forEach { it(this) }
+        changeListeners.remove(listener)
     }
 
     override fun updateFinished() {

--- a/src/test/kotlin/com/github/hanseter/json/editor/DiscriminatedUnionTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/DiscriminatedUnionTest.kt
@@ -1,0 +1,170 @@
+package com.github.hanseter.json.editor
+
+import com.github.hanseter.json.editor.types.DiscriminatedOneOfModel
+import com.github.hanseter.json.editor.ui.ControlTreeItemData
+import javafx.scene.control.ComboBox
+import javafx.stage.Stage
+import org.everit.json.schema.Schema
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.testfx.framework.junit5.ApplicationExtension
+import org.testfx.framework.junit5.Start
+
+@ExtendWith(ApplicationExtension::class)
+class DiscriminatedUnionTest {
+
+    lateinit var editor: JsonPropertiesEditor
+
+    @Start
+    fun start(stage: Stage) {
+        editor = JsonPropertiesEditor()
+    }
+
+    @Test
+    fun usesDiscUnion() {
+
+        val schema = getDiscUnionSchema("a", "b")
+
+        editor.display("1", "1", JSONObject(), schema) { it }
+        val itemTable = editor.getItemTable()
+        val item = itemTable.root.children.first().findChildWithKey("union")!!
+        val itemData = item.value as ControlTreeItemData
+
+        assertThat(itemData.typeControl.model, instanceOf(DiscriminatedOneOfModel::class.java))
+        assertThat(
+            (itemData.typeControl.model as DiscriminatedOneOfModel).discriminatorKey,
+            `is`("disc")
+        )
+    }
+
+    @Test
+    fun usesCorrectOption() {
+        val schema = getDiscUnionSchema("A", "B", "C")
+
+        editor.display(
+            "1", "1", JSONObject(
+                mapOf(
+                    "union" to mapOf(
+                        "disc" to "B",
+                        // deliberately using a different value prop to see if the discrimator overrules it
+                        "valueA" to "foo"
+                    )
+                )
+            ), schema
+        ) { it }
+
+        val control = editor.getControlInTable("union") as ComboBox<Schema>
+
+        assertThat(control.selectionModel.selectedIndex, `is`(1))
+    }
+
+    @Test
+    fun doesntUseDiscUnion() {
+
+
+        val schema = JSONObject(
+            mapOf(
+                "properties" to mapOf(
+                    "noDisc" to mapOf(
+                        "oneOf" to listOf(
+                            generateOption("A", null),
+                            generateOption("B", null)
+                        )
+                    ),
+                    "notRequired" to mapOf(
+                        "oneOf" to listOf(
+                            generateOption("A", optionalDisc = false),
+                            generateOption("B", optionalDisc = true)
+                        )
+                    ),
+                    "differentDiscs" to mapOf(
+                        "oneOf" to listOf(
+                            generateOption("A", discKey = "disc"),
+                            generateOption("B", discKey = "different")
+                        )
+                    )
+                )
+            )
+        )
+
+        editor.display("1", "1", JSONObject(), schema) { it }
+        val itemTable = editor.getItemTable()
+
+        for (key in listOf("noDisc", "notRequired", "differentDiscs")) {
+            val item = itemTable.root.children.first().findChildWithKey(key)!!
+            val itemData = item.value as ControlTreeItemData
+
+            assertThat(
+                itemData.typeControl.model,
+                not(instanceOf(DiscriminatedOneOfModel::class.java))
+            )
+        }
+    }
+
+    @Test
+    fun setsDiscriminatorWhenSwitching() {
+        val schema = getDiscUnionSchema("D", "E", "F")
+
+        val data = JSONObject()
+
+        editor.display("1", "1", data, schema) { it }
+
+
+        val itemTable = editor.getItemTable()
+        val item = itemTable.root.children.first().findChildWithKey("union")!!
+        val control = editor.getControlInTable("union") as ComboBox<Schema>
+        control.selectionModel.selectFirst()
+
+        assertThat(data.optJSONObject("union")?.opt("disc"), `is`("D"))
+
+        control.selectionModel.select(2)
+
+        assertThat(data.optJSONObject("union")?.opt("disc"), `is`("F"))
+    }
+
+
+    companion object {
+
+        fun generateOption(
+            identifier: String,
+            discKey: String? = "disc",
+            optionalDisc: Boolean = false
+        ): Map<String, Any> {
+
+            val props = mutableMapOf(
+                "value$identifier" to mapOf(
+                    "type" to "string"
+                )
+            )
+
+            discKey?.let {
+                props.put(it, mapOf("const" to identifier))
+            }
+
+            return mapOf(
+                "type" to "object",
+                "title" to identifier,
+                "properties" to props,
+                "required" to listOfNotNull(if (optionalDisc) null else discKey, "value$identifier")
+            )
+        }
+
+        fun getDiscUnionSchema(vararg options: String): JSONObject {
+
+            return JSONObject(
+                mapOf(
+                    "properties" to mapOf(
+                        "union" to mapOf(
+                            "oneOf" to options.map { generateOption(it) }
+                        )
+                    )
+                )
+            )
+        }
+
+    }
+
+}

--- a/src/test/resources/discUnionTestSchema.json
+++ b/src/test/resources/discUnionTestSchema.json
@@ -100,6 +100,24 @@
           ]
         }
       ]
+    },
+    "scalar": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "justObj": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/src/test/resources/discUnionTestSchema.json
+++ b/src/test/resources/discUnionTestSchema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "noUnion": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "val": {
+              "type": "string",
+              "minLength": 2
+            }
+          },
+          "required": [
+            "val"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "val": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "val"
+          ]
+        }
+      ]
+    },
+    "union": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "option": {
+              "const": 42
+            },
+            "val": {
+              "type": "string",
+              "minLength": 2
+            }
+          },
+          "required": [
+            "option",
+            "val"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "option": {
+              "const": "bool"
+            },
+            "val": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "option",
+            "val"
+          ]
+        }
+      ]
+    },
+    "unionWithTypes": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "option": {
+              "type": "string",
+              "const": "str"
+            },
+            "val": {
+              "type": "string",
+              "minLength": 2
+            }
+          },
+          "required": [
+            "option",
+            "val"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "option": {
+              "type": "string",
+              "const": "bool"
+            },
+            "val": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "option",
+            "val"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds special support for `oneOf` schemas using a discriminated union pattern. Any time such a pattern is detected, the editor will use the discriminator property to decide the active `oneOf` option instead of schema validity, which will hopefully make the option deciding process more predictable.

A schema is considered a discriminated union if

- all options are objects
- there is a property with a given key in all options that has a `const` value
- that property is required in all options
- the `const` value is different for every option

A set of tests was provided for this functionality. There is also an example schema for use in the test app.

In addition (unrelated to `oneOf`s), an elements title row will properly update its validation status. Previously, if it was initially invalid, the error marker would never vanish even if the data was corrected in the editor.