### PR TITLE
Show validation errors inside tooltip

### DIFF
--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -44,7 +44,11 @@ class JsonPropertiesEditor(
         id = "itemTable"
         rowFactory = Callback { TreeItemDataRow() }
 
-        stylesheets.add(this@JsonPropertiesEditor.javaClass.getResource("TreeTableView.css")!!.toExternalForm())
+        stylesheets.add(
+            this@JsonPropertiesEditor.javaClass
+                .getResource("TreeTableView.css")!!
+                .toExternalForm()
+        )
         columns.addAll(createKeyColumn(), createControlColumn(), createActionColumn())
         isShowRoot = false
         columnResizePolicy = TreeTableView.CONSTRAINED_RESIZE_POLICY
@@ -174,7 +178,7 @@ class JsonPropertiesEditor(
         }
 
     private inner class KeyCell : TreeTableCell<TreeItemData, TreeItemData>() {
-        private var changeListener: ((TreeItemData) -> Unit) = this::updateValidation
+        private var changeListener: ((TreeItemData) -> Unit) = this::updateUi
         override fun updateItem(item: TreeItemData?, empty: Boolean) {
             getItem()?.removeChangeListener(changeListener)
             super.updateItem(item, empty)
@@ -183,7 +187,9 @@ class JsonPropertiesEditor(
                 Label().apply {
                     text =
                         dataItem.title + if (viewOptions.markRequired && dataItem.required) " *" else ""
-                    tooltip = dataItem.description?.let { Tooltip(it) }
+
+                    updateTooltip(dataItem)
+
                     skin = DecoratableLabelSkin(this)
                 }
             }
@@ -194,6 +200,33 @@ class JsonPropertiesEditor(
                 graphic = node
                 updateValidation(item)
                 item.registerChangeListener(changeListener)
+            }
+        }
+
+        fun updateUi(treeItemData: TreeItemData) {
+            updateValidation(treeItemData)
+            updateTooltip(treeItemData)
+        }
+
+        fun updateTooltip(treeItemData: TreeItemData) {
+            val desc = treeItemData.description
+            val validationMessage = treeItemData.validationMessage
+
+            if (desc != null) {
+                tooltip = Tooltip().apply {
+                    styleClass.add("json-props-editor-tooltip")
+                    contentDisplay = ContentDisplay.BOTTOM
+
+                    text = desc
+
+                    validationMessage?.let {
+                        graphic = Label(it).apply {
+                            styleClass.add("error-display")
+                        }
+                    }
+                }
+            } else {
+                tooltip = null
             }
         }
 

--- a/src/main/resources/com/github/hanseter/json/editor/TreeTableView.css
+++ b/src/main/resources/com/github/hanseter/json/editor/TreeTableView.css
@@ -135,3 +135,18 @@
     -fx-spacing: 10px;
     -fx-alignment: center-left;
 }
+
+
+/**
+ TOOLTIPS
+ */
+
+.json-props-editor-tooltip .error-display {
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.8), 5, 0, 0, 5);
+    -fx-font-weight: bold;
+    -fx-padding: 5;
+    -fx-border-width: 1;
+    -fx-background-color: FBEFEF;
+    -fx-text-fill: cc0033;
+    -fx-border-color: cc0033;
+}

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -337,6 +337,7 @@
           "type": "boolean"
         },
         "requiredButNullable": {
+          "description": "This field is required, but also nullable.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
Pretty much what it says on the tin. If a field has both a description and a validation error, the error is displayed inside the tooltip. The CSS was manually copied over from ControlsFX because I couldn't easily replicate the selectors.