### PR TITLE
Allow LabelledTextFields to have a custom TextFieldBehavior

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -16,4 +16,4 @@ jobs:
           java-package: jdk+fx
           cache: maven
       - name: Run Maven Tests
-        run: mvn --batch-mode --update-snapshots verify
+        run: mvn --batch-mode --update-snapshots verify -Dtestfx.robot=glass -Dtestfx.headless=true -Dglass.platform=Monocle -Dmonocle.platform=Headless -Dprism.order=sw -Dheadless.geometry=1000x1000-32

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'zulu'
+          java-package: jdk+fx
           cache: maven
       - name: Run Maven Tests
         run: mvn --batch-mode --update-snapshots verify
-        

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -1,0 +1,19 @@
+name: Test Runner
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+          cache: maven
+      - name: Run Maven Tests
+        run: mvn --batch-mode --update-snapshots verify
+        

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.31</version>
+    <version>0.0.32</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/LabelledTextField.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/LabelledTextField.kt
@@ -1,5 +1,6 @@
 package com.github.hanseter.json.editor.ui
 
+import com.sun.javafx.scene.control.behavior.TextFieldBehavior
 import com.sun.javafx.scene.control.skin.TextFieldSkin
 import javafx.beans.property.SimpleStringProperty
 import javafx.beans.property.StringProperty
@@ -29,7 +30,12 @@ class LabelledTextField(text: String) : TextField(text) {
     }
 }
 
-class LabelledTextFieldSkin(private val textField: LabelledTextField) : TextFieldSkin(textField) {
+class LabelledTextFieldSkin(
+    private val textField: LabelledTextField,
+    textFieldBehavior: TextFieldBehavior
+) : TextFieldSkin(textField, textFieldBehavior) {
+
+    constructor(textField: LabelledTextField) : this(textField, TextFieldBehavior(textField))
 
     companion object {
         const val LABEL_SEPARATOR_WIDTH = 5.0


### PR DESCRIPTION
Adds a constructor to `LabelledTextFieldSkin` to mirror the one in `TextFieldSkin` that takes a `TextFieldBehavior`. Also adds a GitHub Action to automatically run the tests when something is pushed. Let's see if that works in PRs.