### PR TITLE
Fix nullable arrays

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.32</version>
+    <version>0.0.33</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ArrayControl.kt
@@ -28,6 +28,8 @@ class ArrayControl(override val model: ArrayModel, private val context: EditorCo
         override val control = TypeWithChildrenStatusControl("To Empty List") {
             model.value = JSONArray()
             valuesChanged()
+        }.apply {
+            isDisable = model.schema.readOnly
         }
 
         override fun updateDisplayedValue() {

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/EnumControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/EnumControl.kt
@@ -1,6 +1,7 @@
 package com.github.hanseter.json.editor.controls
 
 import com.github.hanseter.json.editor.types.EnumModel
+import javafx.beans.binding.Bindings
 import javafx.beans.property.Property
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.value.ChangeListener
@@ -9,6 +10,7 @@ import javafx.scene.control.ContentDisplay
 import javafx.scene.control.Label
 import javafx.scene.control.ListCell
 import javafx.scene.control.ListView
+import javafx.scene.shape.Rectangle
 import javafx.util.Callback
 import javafx.util.StringConverter
 import org.controlsfx.control.SearchableComboBox
@@ -39,10 +41,26 @@ class EnumControl(private val model: EnumModel) : ControlWithProperty<String?>, 
 
                 private val descLabel = Label().apply {
                     styleClass.add("enum-desc-label")
+
+                    val descClip = Rectangle().also {
+
+                        it.widthProperty().bind(widthProperty())
+                        it.heightProperty().bind(heightProperty())
+
+                        // if the label is wider than the space available, its layoutX will be negative
+                        // and it will be rendered outside the combobox cell (on the left side)
+                        // with this, we clip it to be always contained within it
+                        it.layoutXProperty().bind(Bindings.max(0, layoutXProperty().negate()))
+                        it.layoutYProperty().bind(layoutYProperty())
+                    }
+
+                    clip = descClip
                 }
 
                 override fun updateItem(item: String?, empty: Boolean) {
                     super.updateItem(item, empty)
+
+
 
                     if (item == null || empty) {
                         text = ""

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/ObjectControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/ObjectControl.kt
@@ -19,6 +19,8 @@ interface ObjectControl : TypeControl {
     class LazyObjectControl(private val objectControl: ObjectControl) : LazyControl {
         override val control = TypeWithChildrenStatusControl("Create") {
             objectControl.model.value = JSONObject()
+        }.apply {
+            isDisable = objectControl.model.schema.readOnly
         }
 
         override fun updateDisplayedValue() {

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/OneOfControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/OneOfControl.kt
@@ -35,6 +35,8 @@ class OneOfControl(override val model: OneOfModel) : TypeControl {
             items.addAll(model.schema.baseSchema.subschemas)
             converter = SchemaTitleStringConverter
             selectionModel.selectedItemProperty().addListener(selectionListener)
+
+            isDisable = model.schema.readOnly
         }
 
         override fun updateDisplayedValue() {

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/TupleControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/TupleControl.kt
@@ -30,7 +30,10 @@ class TupleControl(override val model: TupleModel, context: EditorContext) : Typ
     override fun createLazyControl(): LazyControl = TupleLazyControl()
 
     private inner class TupleLazyControl : LazyControl {
-        override val control = TypeWithChildrenStatusControl("Create") { model.value = JSONArray() }
+        override val control =
+            TypeWithChildrenStatusControl("Create") { model.value = JSONArray() }.apply {
+                isDisable = model.schema.readOnly
+            }
 
         override fun updateDisplayedValue() {
             if (model.rawValue == JSONObject.NULL || (model.rawValue == null && model.defaultValue == null)) {

--- a/src/main/kotlin/com/github/hanseter/json/editor/schemaExtensions/Extensions.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/schemaExtensions/Extensions.kt
@@ -1,9 +1,16 @@
 package com.github.hanseter.json.editor.schemaExtensions
 
 import org.everit.json.schema.CombinedSchema
+import org.everit.json.schema.NullSchema
 import java.lang.reflect.Method
 
-private val isSyntheticMethod: Method = CombinedSchema::class.java.getDeclaredMethod("isSynthetic").apply { isAccessible = true }
+private val isSyntheticMethod: Method =
+    CombinedSchema::class.java.getDeclaredMethod("isSynthetic").apply { isAccessible = true }
+
+val CombinedSchema.isNullableSchema: Boolean
+    get() = this.criterion == CombinedSchema.ANY_CRITERION
+            && this.subschemas.size == 2
+            && this.subschemas.any { it is NullSchema }
 
 val CombinedSchema.synthetic: Boolean
-    get() = isSyntheticMethod.invoke(this) as Boolean
+    get() = isNullableSchema || isSyntheticMethod.invoke(this) as Boolean

--- a/src/main/kotlin/com/github/hanseter/json/editor/util/BindableJsonArrayEntry.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/util/BindableJsonArrayEntry.kt
@@ -6,7 +6,7 @@ class BindableJsonArrayEntry(private val parentArr: BindableJsonArray, private v
 	BindableJsonType(parentArr) {
 
 	override fun updateFromChild(child: BindableJsonType, schema: EffectiveSchema<*>) {
-		parentArr.updateFromChild(this, schema.parent!!)
+		parentArr.updateFromChild(this, schema.nonSyntheticAncestor!!)
 	}
 
 	override fun setValueInternal(schema: EffectiveSchema<*>, value: Any?) =

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -41,7 +41,7 @@ class JsonPropertiesEditorTestApp : Application() {
         propEdit.resolutionScopeProvider = customResolutionScopeProvider
 
 
-        display(propEdit, "DefaultObjectsSchema.json", JSONObject())
+        display(propEdit, "completeValidationTestSchema.json", JSONObject())
 
         propEdit.valid.addListener { _, _, new -> println("Is valid: $new") }
         primaryStage.scene = Scene(buildUi(propEdit), 800.0, 800.0)

--- a/src/test/resources/completeValidationTestSchema.json
+++ b/src/test/resources/completeValidationTestSchema.json
@@ -222,6 +222,34 @@
             },
             "default": {}
           }
+        },
+        "nullableSubItems": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "subObj": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "subProp": {
+                    "type": "string"
+                  }
+                }
+              },
+              "subArr": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Nullable arrays inside other arrays could not be expanded, nor could items be added to them.

Also, some controls were still enabled even if a schema is set to read-only.

Finally, clips the description of an enum control's combo box to the combo box so long descriptions can't be rendered outside of the combo box.