### PR TITLE
Add customization object feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ hs_err_pid*
 .settings
 target
 bin
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.36</version>
+    <version>0.0.37</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -186,7 +186,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
             isSortable = false
         }
 
-    private inner class KeyCell : TreeTableCell<TreeItemData, TreeItemData>() {
+    inner class KeyCell : TreeTableCell<TreeItemData, TreeItemData>() {
         private var changeListener: ((TreeItemData) -> Unit) = this::updateUi
 
         init {

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -3,6 +3,7 @@ package com.github.hanseter.json.editor
 import com.github.hanseter.json.editor.actions.*
 import com.github.hanseter.json.editor.types.TypeModel
 import com.github.hanseter.json.editor.ui.*
+import com.github.hanseter.json.editor.util.CustomizationObject
 import com.github.hanseter.json.editor.util.LazyControl
 import com.github.hanseter.json.editor.util.ViewOptions
 import com.github.hanseter.json.editor.validators.IdReferenceValidator
@@ -20,10 +21,11 @@ import org.controlsfx.validation.decoration.GraphicValidationDecoration
 import org.json.JSONObject
 import java.net.URI
 
-class JsonPropertiesEditor(
+class JsonPropertiesEditor @JvmOverloads constructor(
     private val readOnly: Boolean = false,
     viewOptions: ViewOptions = ViewOptions(),
     actions: List<EditorAction> = listOf(ResetToDefaultAction, ResetToNullAction),
+    private val customizationObject: CustomizationObject? = null
 ) : StackPane() {
     var referenceProposalProvider: IdReferenceProposalProvider =
         IdReferenceProposalProvider.IdReferenceProposalProviderEmpty
@@ -40,6 +42,9 @@ class JsonPropertiesEditor(
     private val idsToPanes = mutableMapOf<String, JsonPropertiesPane>()
     private val rootItem: FilterableTreeItem<TreeItemData> =
         FilterableTreeItem(StyledTreeItemData("root", listOf()))
+
+    private val keyColumn = createKeyColumn()
+
     private val treeTableView = TreeTableView<TreeItemData>().apply {
         id = "itemTable"
         rowFactory = Callback { TreeItemDataRow() }
@@ -49,7 +54,7 @@ class JsonPropertiesEditor(
                 .getResource("TreeTableView.css")!!
                 .toExternalForm()
         )
-        columns.addAll(createKeyColumn(), createControlColumn(), createActionColumn())
+        columns.addAll(keyColumn, createControlColumn(), createActionColumn())
         isShowRoot = false
         columnResizePolicy = TreeTableView.CONSTRAINED_RESIZE_POLICY
         root = rootItem
@@ -94,7 +99,7 @@ class JsonPropertiesEditor(
             title, objId, obj,
             schema,
             readOnly,
-            resolutionScope, callback
+            resolutionScope, customizationObject, callback
         )
         pane.fillData(obj)
         idsToPanes[objId] = pane
@@ -151,7 +156,9 @@ class JsonPropertiesEditor(
 
     private fun createTitledPaneForSchema(
         title: String, objId: String, data: JSONObject,
-        rawSchema: JSONObject, readOnly: Boolean, resolutionScope: URI?, callback: OnEditCallback
+        rawSchema: JSONObject, readOnly: Boolean, resolutionScope: URI?,
+        customizationObject: CustomizationObject?,
+        callback: OnEditCallback
     ): JsonPropertiesPane =
         JsonPropertiesPane(
             title,
@@ -164,6 +171,7 @@ class JsonPropertiesEditor(
             actions,
             validators,
             viewOptions,
+            customizationObject,
             callback
         )
 
@@ -179,33 +187,37 @@ class JsonPropertiesEditor(
 
     private inner class KeyCell : TreeTableCell<TreeItemData, TreeItemData>() {
         private var changeListener: ((TreeItemData) -> Unit) = this::updateUi
-        override fun updateItem(item: TreeItemData?, empty: Boolean) {
+
+        init {
+            styleClass.add("key-cell")
+        }
+
+        public override fun updateItem(item: TreeItemData?, empty: Boolean) {
             getItem()?.removeChangeListener(changeListener)
             super.updateItem(item, empty)
 
-            val node = item?.let { dataItem ->
-                Label().apply {
-                    text =
-                        dataItem.title + if (viewOptions.markRequired && dataItem.required) " *" else ""
-
-                    updateTooltip(dataItem)
-
-                    skin = DecoratableLabelSkin(this)
-                }
-            }
-            if (node == null || empty) {
+            if (item == null || empty) {
                 text = null
                 graphic = null
             } else {
-                graphic = node
-                updateValidation(item)
+                updateUi(item)
                 item.registerChangeListener(changeListener)
             }
         }
 
         fun updateUi(treeItemData: TreeItemData) {
+            updateLabel(treeItemData)
             updateValidation(treeItemData)
             updateTooltip(treeItemData)
+        }
+
+        fun updateLabel(treeItemData: TreeItemData) {
+            graphic = Label().apply {
+                text =
+                    treeItemData.title + if (viewOptions.markRequired && treeItemData.required) " *" else ""
+
+                skin = DecoratableLabelSkin(this)
+            }
         }
 
         fun updateTooltip(treeItemData: TreeItemData) {

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -4,6 +4,7 @@ import com.github.hanseter.json.editor.actions.*
 import com.github.hanseter.json.editor.types.TypeModel
 import com.github.hanseter.json.editor.ui.*
 import com.github.hanseter.json.editor.util.CustomizationObject
+import com.github.hanseter.json.editor.util.DefaultCustomizationObject
 import com.github.hanseter.json.editor.util.LazyControl
 import com.github.hanseter.json.editor.util.ViewOptions
 import com.github.hanseter.json.editor.validators.IdReferenceValidator
@@ -171,7 +172,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
             actions,
             validators,
             viewOptions,
-            customizationObject,
+            customizationObject ?: DefaultCustomizationObject,
             callback
         )
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -26,7 +26,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
     private val readOnly: Boolean = false,
     viewOptions: ViewOptions = ViewOptions(),
     actions: List<EditorAction> = listOf(ResetToDefaultAction, ResetToNullAction),
-    private val customizationObject: CustomizationObject? = null
+    private val customizationObject: CustomizationObject = DefaultCustomizationObject
 ) : StackPane() {
     var referenceProposalProvider: IdReferenceProposalProvider =
         IdReferenceProposalProvider.IdReferenceProposalProviderEmpty
@@ -158,7 +158,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
     private fun createTitledPaneForSchema(
         title: String, objId: String, data: JSONObject,
         rawSchema: JSONObject, readOnly: Boolean, resolutionScope: URI?,
-        customizationObject: CustomizationObject?,
+        customizationObject: CustomizationObject,
         callback: OnEditCallback
     ): JsonPropertiesPane =
         JsonPropertiesPane(
@@ -172,7 +172,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
             actions,
             validators,
             viewOptions,
-            customizationObject ?: DefaultCustomizationObject,
+            customizationObject,
             callback
         )
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -7,10 +7,7 @@ import com.github.hanseter.json.editor.controls.TupleControl
 import com.github.hanseter.json.editor.controls.TypeControl
 import com.github.hanseter.json.editor.extensions.SimpleEffectiveSchema
 import com.github.hanseter.json.editor.ui.*
-import com.github.hanseter.json.editor.util.EditorContext
-import com.github.hanseter.json.editor.util.PropertyGrouping
-import com.github.hanseter.json.editor.util.RootBindableType
-import com.github.hanseter.json.editor.util.ViewOptions
+import com.github.hanseter.json.editor.util.*
 import com.github.hanseter.json.editor.validators.JSONPointer
 import com.github.hanseter.json.editor.validators.ValidationEngine
 import com.github.hanseter.json.editor.validators.Validator
@@ -32,6 +29,7 @@ class JsonPropertiesPane(
     private val actions: List<EditorAction>,
     private val validators: List<Validator>,
     viewOptions: ViewOptions,
+    private val customizationObject: CustomizationObject?,
     private val changeListener: JsonPropertiesEditor.OnEditCallback
 ) {
     val treeItem: FilterableTreeItem<TreeItemData> =
@@ -143,7 +141,9 @@ class JsonPropertiesPane(
                     actions,
                     actionHandler,
                     objId,
-                    validators.filter { it.selector.matches(control.model) })
+                    validators.filter { it.selector.matches(control.model) },
+                    customizationObject
+                )
             )
         if (control is ObjectControl) {
             addObjectControlChildren(item, control)

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -29,7 +29,7 @@ class JsonPropertiesPane(
     private val actions: List<EditorAction>,
     private val validators: List<Validator>,
     viewOptions: ViewOptions,
-    private val customizationObject: CustomizationObject?,
+    private val customizationObject: CustomizationObject,
     private val changeListener: JsonPropertiesEditor.OnEditCallback
 ) {
     val treeItem: FilterableTreeItem<TreeItemData> =

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
@@ -130,7 +130,7 @@ class ControlTreeItemData(
         get() = customizationObject.getTitle(typeControl.model, typeControl.model.schema.title)
 
     override val description: String?
-        get() = typeControl.model.schema.description
+        get() = customizationObject.getDescription(typeControl.model, typeControl.model.schema.description)
 
     override val required: Boolean
         get() = typeControl.model.schema.required

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
@@ -122,12 +122,12 @@ class ControlTreeItemData(
     private val actionHandler: (Event, EditorAction, TypeControl) -> Unit,
     private val objId: String,
     val validators: List<Validator>,
-    private val customizationObject: CustomizationObject?
+    private val customizationObject: CustomizationObject
 ) : TreeItemData {
     private val changeListeners: MutableList<(TreeItemData) -> Unit> = mutableListOf()
 
     override val title: String
-        get() = customizationObject?.getTitle(typeControl.model) ?: typeControl.model.schema.title
+        get() = customizationObject.getTitle(typeControl.model, typeControl.model.schema.title)
 
     override val description: String?
         get() = typeControl.model.schema.description

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
@@ -3,6 +3,7 @@ package com.github.hanseter.json.editor.ui
 import com.github.hanseter.json.editor.actions.ActionsContainer
 import com.github.hanseter.json.editor.actions.EditorAction
 import com.github.hanseter.json.editor.controls.TypeControl
+import com.github.hanseter.json.editor.util.CustomizationObject
 import com.github.hanseter.json.editor.util.LazyControl
 import com.github.hanseter.json.editor.validators.Validator
 import javafx.beans.binding.Bindings
@@ -120,11 +121,13 @@ class ControlTreeItemData(
     private val actions: List<EditorAction>,
     private val actionHandler: (Event, EditorAction, TypeControl) -> Unit,
     private val objId: String,
-    val validators: List<Validator>
+    val validators: List<Validator>,
+    private val customizationObject: CustomizationObject?
 ) : TreeItemData {
     private val changeListeners: MutableList<(TreeItemData) -> Unit> = mutableListOf()
 
-    override val title = typeControl.model.schema.title
+    override val title: String
+        get() = customizationObject?.getTitle(typeControl.model) ?: typeControl.model.schema.title
 
     override val description: String?
         get() = typeControl.model.schema.description

--- a/src/main/kotlin/com/github/hanseter/json/editor/util/CustomizationObject.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/util/CustomizationObject.kt
@@ -1,0 +1,19 @@
+package com.github.hanseter.json.editor.util
+
+import com.github.hanseter.json.editor.types.TypeModel
+
+/**
+ * An object that can be used to customize the behavior and appearance of the editor.
+ */
+interface CustomizationObject {
+
+    /**
+     * Gets the title for a given element.
+     *
+     * If `null` is returned (the default), the title from the schema is used instead.
+     */
+    fun getTitle(model: TypeModel<*, *>): String? {
+        return null
+    }
+
+}

--- a/src/main/kotlin/com/github/hanseter/json/editor/util/CustomizationObject.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/util/CustomizationObject.kt
@@ -14,6 +14,13 @@ interface CustomizationObject {
         return defaultTitle
     }
 
+    /**
+     * Gets the description for a given element.
+     */
+    fun getDescription(model: TypeModel<*, *>, defaultDescription: String?): String? {
+        return defaultDescription
+    }
+
 }
 
 object DefaultCustomizationObject : CustomizationObject

--- a/src/main/kotlin/com/github/hanseter/json/editor/util/CustomizationObject.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/util/CustomizationObject.kt
@@ -9,11 +9,11 @@ interface CustomizationObject {
 
     /**
      * Gets the title for a given element.
-     *
-     * If `null` is returned (the default), the title from the schema is used instead.
      */
-    fun getTitle(model: TypeModel<*, *>): String? {
-        return null
+    fun getTitle(model: TypeModel<*, *>, defaultTitle: String): String {
+        return defaultTitle
     }
 
 }
+
+object DefaultCustomizationObject : CustomizationObject

--- a/src/test/kotlin/com/github/hanseter/json/editor/CustomizationObjectTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/CustomizationObjectTest.kt
@@ -1,0 +1,71 @@
+package com.github.hanseter.json.editor
+
+import com.github.hanseter.json.editor.types.TypeModel
+import com.github.hanseter.json.editor.util.CustomizationObject
+import javafx.scene.control.Label
+import javafx.scene.control.Labeled
+import javafx.scene.control.TextField
+import javafx.stage.Stage
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.testfx.framework.junit5.ApplicationExtension
+import org.testfx.framework.junit5.Start
+
+@ExtendWith(ApplicationExtension::class)
+class CustomizationObjectTest {
+
+    lateinit var editor: JsonPropertiesEditor
+
+    @Start
+    fun start(stage: Stage) {
+        editor = JsonPropertiesEditor()
+    }
+
+    @Test
+    fun testTitleCustomization() {
+        val schema = JSONObject("""
+{
+    "type":"object",
+    "properties": {
+        "foo": {
+            "type": "string"
+        },
+        "notFoo": {
+            "type": "string"
+        }
+    }
+}""")
+        val editor = JsonPropertiesEditor(
+            customizationObject = object : CustomizationObject {
+
+                override fun getTitle(model: TypeModel<*, *>, defaultTitle: String): String {
+                    if (model.schema.pointer == listOf("foo")) {
+                        return "bar" + model.value
+                    }
+                    return defaultTitle
+                }
+
+            }
+        )
+
+        val json = JSONObject("""{"foo":""}""")
+        editor.display("1", "1", json, schema) { it }
+
+        val fooCell = editor.getKeyCellInTable("bar")
+        val notFooCell = editor.getKeyCellInTable("notFoo")
+
+        val fooControl = editor.getControlInTable("bar") as TextField
+
+        MatcherAssert.assertThat((fooCell.graphic as Labeled).text, Matchers.`is`("bar"))
+        MatcherAssert.assertThat((notFooCell.graphic as Labeled).text, Matchers.`is`("notFoo"))
+
+        fooControl.text = "something"
+
+        MatcherAssert.assertThat((fooCell.graphic as Labeled).text, Matchers.`is`("barsomething"))
+        MatcherAssert.assertThat((notFooCell.graphic as Labeled).text, Matchers.`is`("notFoo"))
+    }
+
+}

--- a/src/test/kotlin/com/github/hanseter/json/editor/CustomizationObjectTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/CustomizationObjectTest.kt
@@ -68,4 +68,41 @@ class CustomizationObjectTest {
         MatcherAssert.assertThat((notFooCell.graphic as Labeled).text, Matchers.`is`("notFoo"))
     }
 
+    @Test
+    fun testDescriptionCustomization() {
+        val schema = JSONObject("""
+{
+    "type":"object",
+    "properties": {
+        "foo": {
+            "type": "string"
+        }
+    }
+}""")
+        val editor = JsonPropertiesEditor(
+            customizationObject = object : CustomizationObject {
+
+                override fun getDescription(
+                    model: TypeModel<*, *>,
+                    defaultDescription: String?
+                ): String? {
+                    if (model.schema.pointer == listOf("foo")) {
+                        return "fooDesc"
+                    }
+                    return defaultDescription
+                }
+
+            }
+        )
+
+        val json = JSONObject("""{"foo":""}""")
+        editor.display("1", "1", json, schema) { it }
+
+        val fooCell = editor.getKeyCellInTable("foo")
+
+        MatcherAssert.assertThat(fooCell.tooltip, Matchers.notNullValue())
+        MatcherAssert.assertThat(fooCell.tooltip.text, Matchers.`is`("fooDesc"))
+
+    }
+
 }

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTest.kt
@@ -98,3 +98,14 @@ fun JsonPropertiesEditor.getControlInTable(itemData: TreeItemData?): Node {
     cell.updateItem(itemData, false)
     return cell.graphic
 }
+
+fun JsonPropertiesEditor.getKeyCellInTable(key: String): JsonPropertiesEditor.KeyCell =
+    getKeyCellInTable(getItemTable().root.findChildWithKeyRecursive(key)?.value)
+
+fun JsonPropertiesEditor.getKeyCellInTable(itemData: TreeItemData?): JsonPropertiesEditor.KeyCell {
+    val table = getItemTable()
+    val column = table.columns[0] as TreeTableColumn<TreeItemData, TreeItemData>
+    val cell = column.cellFactory.call(column) as JsonPropertiesEditor.KeyCell
+    cell.updateItem(itemData, false)
+    return cell
+}

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -180,14 +180,14 @@ class JsonPropertiesEditorTestApp : Application() {
 
 class TestCustomizationObject : CustomizationObject {
 
-    override fun getTitle(model: TypeModel<*, *>): String? {
+    override fun getTitle(model: TypeModel<*, *>, defaultTitle: String): String {
         if (model.schema.pointer == listOf("combined object", "b")) {
             return "not b (${model.value})"
         }
         if (model.schema.pointer == listOf("combined object")) {
             return "combined object (${(model.value as? JSONObject)?.optString("a")})"
         }
-        return null
+        return defaultTitle
     }
 
 }

--- a/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditorTestApp.kt
@@ -1,6 +1,8 @@
 package com.github.hanseter.json.editor
 
+import com.github.hanseter.json.editor.types.TypeModel
 import com.github.hanseter.json.editor.ui.PropertiesEditorToolbar
+import com.github.hanseter.json.editor.util.CustomizationObject
 import com.github.hanseter.json.editor.util.IdRefDisplayMode
 import com.github.hanseter.json.editor.util.PropertyGrouping
 import com.github.hanseter.json.editor.util.ViewOptions
@@ -36,7 +38,7 @@ class JsonPropertiesEditorTestApp : Application() {
             numberOfInitiallyOpenedObjects = 2,
         )
 
-        val propEdit = JsonPropertiesEditor(false, viewOptions)
+        val propEdit = JsonPropertiesEditor(false, viewOptions, customizationObject = TestCustomizationObject())
         propEdit.referenceProposalProvider = ReferenceProvider
         propEdit.resolutionScopeProvider = customResolutionScopeProvider
 
@@ -174,4 +176,18 @@ class JsonPropertiesEditorTestApp : Application() {
             println("Request to open $id")
         }
     }
+}
+
+class TestCustomizationObject : CustomizationObject {
+
+    override fun getTitle(model: TypeModel<*, *>): String? {
+        if (model.schema.pointer == listOf("combined object", "b")) {
+            return "not b (${model.value})"
+        }
+        if (model.schema.pointer == listOf("combined object")) {
+            return "combined object (${(model.value as? JSONObject)?.optString("a")})"
+        }
+        return null
+    }
+
 }


### PR DESCRIPTION
Adds a `CustomizationObject` interface, which currently only allows specifying a callback to change any element's title, but may be expanded in the future.