### PR TITLE
Fix bug with oneOfs and with focus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.41</version>
+    <version>0.0.42</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -14,7 +14,9 @@ import javafx.application.Platform
 import javafx.beans.binding.Bindings
 import javafx.beans.property.ReadOnlyBooleanProperty
 import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableBooleanValue
+import javafx.beans.value.ObservableValue
 import javafx.beans.value.WeakChangeListener
 import javafx.scene.control.*
 import javafx.scene.layout.StackPane
@@ -322,10 +324,31 @@ class JsonPropertiesEditor @JvmOverloads constructor(
         private var changeListener: ((TreeItemData) -> Unit) = this::updateControl
         private var lazyControl: LazyControl? = null
 
+        // if we don't delay this, we run into issues when collapsing a cell that is currently focused
+        // but with the delay, it sometimes happens that the control isn't actually focused anymore by the time we get to the runLater, so we check again
+        private val focusListener =
+            ChangeListener { obs, _, new: Boolean ->
+                if (new) {
+                    Platform.runLater {
+                        if (obs.value) {
+                            println("Focus received ${treeTableRow.index}, ${treeTableView.expandedItemCount}")
+                            treeTableView.selectionModel.select(treeTableRow.index, tableColumn)
+                        }
+                    }
+
+                }
+            }
+
         init {
-            selectedProperty().addListener { _, _, newValue ->
+            selectedProperty().addListener { obs, _, newValue ->
                 if (newValue) {
-                    lazyControl?.control?.requestFocus()
+                    Platform.runLater {
+                        if (obs.value) {
+                            println("Cell selected ${treeTableRow.index}, ${treeTableView.expandedItemCount}")
+                            lazyControl?.control?.requestFocus()
+                        }
+                    }
+
                 }
             }
         }
@@ -334,19 +357,15 @@ class JsonPropertiesEditor @JvmOverloads constructor(
             getItem()?.removeChangeListener(changeListener)
             super.updateItem(item, empty)
 
+            lazyControl?.control?.focusedProperty()?.removeListener(focusListener)
+
             lazyControl = item?.createControl()
             if (item == null || empty) {
                 text = null
                 graphic = null
             } else {
-                graphic = lazyControl?.control.also {
-                    it?.focusedProperty()?.addListener(WeakChangeListener{ _, _, newValue ->
-                        if(newValue){
-                            Platform.runLater {
-                                treeTableView.selectionModel.clearAndSelect(treeTableRow.index,tableColumn)
-                            }
-                        }
-                    })
+                graphic = lazyControl?.control?.also {
+                    it.focusedProperty().addListener(focusListener)
                 }
                 updateControl(item)
                 item.registerChangeListener(changeListener)

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -331,7 +331,6 @@ class JsonPropertiesEditor @JvmOverloads constructor(
                 if (new) {
                     Platform.runLater {
                         if (obs.value) {
-                            println("Focus received ${treeTableRow.index}, ${treeTableView.expandedItemCount}")
                             treeTableView.selectionModel.select(treeTableRow.index, tableColumn)
                         }
                     }
@@ -344,7 +343,6 @@ class JsonPropertiesEditor @JvmOverloads constructor(
                 if (newValue) {
                     Platform.runLater {
                         if (obs.value) {
-                            println("Cell selected ${treeTableRow.index}, ${treeTableView.expandedItemCount}")
                             lazyControl?.control?.requestFocus()
                         }
                     }

--- a/src/main/kotlin/com/github/hanseter/json/editor/extensions/EffectiveSchemaOfCombination.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/extensions/EffectiveSchemaOfCombination.kt
@@ -16,4 +16,7 @@ class EffectiveSchemaOfCombination<T : Schema>(override val parent: EffectiveSch
 
     override val propertyName: String
         get() = parent.propertyName
+
+    override val nonSyntheticAncestor: EffectiveSchema<*>?
+        get() = parent.nonSyntheticAncestor
 }

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/TreeTableNavigation.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/TreeTableNavigation.kt
@@ -18,17 +18,17 @@ object TreeTableNavigation {
 
     fun addNavigationToTreeTableView(treeTableView: TreeTableView<TreeItemData>) {
         treeTableView.apply {
-            addEventHandler(KeyEvent.KEY_PRESSED) {
-                if (!(it.isAltDown && it.code.isArrowKey)) {
-                    it.consume()
-                }
-            }
             addEventFilter(KeyEvent.KEY_PRESSED) {
                 if (it.isConsumed) return@addEventFilter
 
                 if (it.code == KeyCode.TAB) {
                     it.consume()
-                    selectNext()
+
+                    if (it.isShiftDown) {
+                        selectPrevious()
+                    } else {
+                        selectNext()
+                    }
                 }
 
                 if (it.code.isArrowKey && it.isAltDown) {
@@ -86,12 +86,26 @@ object TreeTableNavigation {
         }
     }
 
+    private fun TreeTableView<*>.selectPrevious() {
+        val selectedRow = selectionModel.selectedCells.firstOrNull()?.row ?: -1
+        when {
+            selectedRow > 0 -> selectUp()
+            selectedRow == 0 -> selectLast()
+            else -> selectFirst()
+        }
+    }
+
     private fun TreeTableView<*>.scrollToCurrentRow() {
         scrollTo(selectionModel.selectedIndex)
     }
 
     private fun TreeTableView<*>.selectFirst() {
         selectionModel.selectFirst()
+        scrollToCurrentRow()
+    }
+
+    private fun TreeTableView<*>.selectLast() {
+        selectionModel.selectLast()
         scrollToCurrentRow()
     }
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/skins/ToggleSwitchSkin.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/skins/ToggleSwitchSkin.kt
@@ -55,15 +55,17 @@ class ToggleSwitchSkin(checkBox: CheckBox) :
     private fun selectedStateChanged() {
         // Stop the transition if it was already running, has no effect otherwise.
         transition.stop()
-        if (skinnable.isSelected) {
-            transition.rate = 1.0
-            transition.jumpTo(Duration.ZERO)
-        } else {
-            // If we are not selected, we need to go from right to left.
-            transition.rate = -1.0
-            transition.jumpTo(transition.duration)
+        if (skinnable.isArmed) {
+            if (skinnable.isSelected) {
+                transition.rate = 1.0
+                transition.jumpTo(Duration.ZERO)
+            } else {
+                // If we are not selected, we need to go from right to left.
+                transition.rate = -1.0
+                transition.jumpTo(transition.duration)
+            }
+            transition.play()
         }
-        transition.play()
     }
 
     override fun computeMinWidth(

--- a/src/test/resources/discUnionTestSchema.json
+++ b/src/test/resources/discUnionTestSchema.json
@@ -118,6 +118,49 @@
           "type": "string"
         }
       }
+    },
+    "someArrayThing": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "theActualArrayNow": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "const": "foo"
+                    },
+                    "foo": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "const": 2
+                    },
+                    "bar": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes a bug where an array containing an object containing an array containing `oneOf`s of objects would incorrectly update its state.
A regression test was supplied. To make the test simpler, the structure was extended to an array containing an object containing an array containing a `oneOf` of an object containing an array, because that would throw the exception even during validation, instead of when manually updating the UI.

Also fixes a bug where changing the number of visible rows (by creating an object, expanding/collapsing something etc.) would cause the cell focus/selection to bug out and wildly switch between two cells.
The fix isn't really clean, but anything that was either didn't work at all, or did work, but introduce another bug where an `IndexOutOfBoundsException` would be thrown instead.

Also also fixes the new toggle switches animating their transition when being scrolled into view.

Also also also adds <kbd>SHIFT</kbd>+<kbd>TAB</kbd> navigation.

Also also also also fixes the editor swallowing all key events.