### PR TITLE
Change `allOf` resolution mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.42</version>
+    <version>0.0.43</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>
@@ -17,6 +17,7 @@
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.7.0</kotlin.version>
+        <slf4j.version>1.7.32</slf4j.version>
     </properties>
 
     <distributionManagement>
@@ -111,6 +112,11 @@
             <optional>true</optional>
             <version>1.1.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <!-- OSGI specific -->
 
         <dependency>
@@ -155,6 +161,11 @@
             <artifactId>testfx-junit5</artifactId>
             <version>4.0.16-alpha</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
@@ -100,7 +100,7 @@ object SchemaNormalizer {
         target.remove("${"$"}ref")
         referredSchema.keySet().forEach {
             if (!target.has(it)) {
-                target.put(it, referredSchema.get(it))
+                target.put(it, deepCopy(referredSchema.get(it)))
             }
         }
     }

--- a/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
@@ -8,12 +8,15 @@ import org.everit.json.schema.loader.SchemaLoader
 import org.json.JSONArray
 import org.json.JSONObject
 import org.json.JSONTokener
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.io.InputStream
 import java.io.UncheckedIOException
 import java.net.URI
 
 object SchemaNormalizer {
+
+    private val logger = LoggerFactory.getLogger(SchemaNormalizer::class.java)
 
     fun parseSchema(
         schema: JSONObject,
@@ -303,21 +306,29 @@ object SchemaNormalizer {
         if (inlineInItems(subPart, copyTarget)) return
 
         val allOf = subPart.optJSONArray("allOf") ?: return
+
         copyTarget().apply {
             remove("allOf")
-            put("type", "object")
-            put("properties", JSONObject())
         }
-        val order = JSONArray()
-        val notCopiedKeys = copyTarget().keySet() + "order"+"properties"
-        getAllObjectsInAllOf(allOf).forEach { propObj ->
-            merge(copyTarget().getJSONObject("properties"), propObj.getJSONObject("properties"))
-            propObj.optJSONArray("order")?.also { order.put(it) }
-            propObj.optJSONObject("order")?.also { order.put(it) }
+
+        val order = lazy { JSONArray() }
+        val notCopiedKeys = copyTarget().keySet() + "order" + "properties"
+        getAllEntriesInAllOf(allOf).forEach { propObj ->
+            propObj.optJSONObject("properties")?.let { newSubProps ->
+                val oldProps = copyTarget().optJSONObject("properties") ?: JSONObject()
+                merge(oldProps, newSubProps)
+                copyTarget().put("properties", oldProps)
+            }
+            propObj.opt("order")?.let {
+                if (it is JSONObject || it is JSONArray) {
+                    order.value.put(it)
+                }
+            }
+
             merge(copyTarget(), propObj, notCopiedKeys)
         }
-        if (!order.isEmpty) {
-            copyTarget().put("order", order)
+        if (order.isInitialized()) {
+            copyTarget().put("order", order.value)
         }
 
         inlineCompositions(copyTarget(), copyTarget)
@@ -422,6 +433,31 @@ object SchemaNormalizer {
                     } else {
                         emptyList()
                     }
+                }
+            } else {
+                emptyList()
+            }
+        }
+    }
+
+    /**
+     * Gets all sub-schemas inside an `allOf` array.
+     * If the array contains items other than objects, they are filtered out.
+     * If the array contains nested `allOf`s, they are flattened.
+     */
+    private fun getAllEntriesInAllOf(allOf: JSONArray): List<JSONObject> {
+        return (0 until allOf.length()).flatMap { i ->
+            val allOfEntry = allOf.get(i)
+            if (allOfEntry is JSONObject) {
+                val nestedAllOff = allOfEntry.optJSONArray("allOf")
+                if (nestedAllOff != null) {
+                    if ((allOfEntry.keySet() - "allOf").isNotEmpty()) {
+                        logger.warn("Encountered additional content in `allOf` during schema normalization. It will be discarded: {}", allOfEntry.toString())
+                    }
+
+                    getAllEntriesInAllOf(nestedAllOff)
+                } else {
+                    listOf(allOfEntry)
                 }
             } else {
                 emptyList()

--- a/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/SchemaNormalizer.kt
@@ -309,11 +309,12 @@ object SchemaNormalizer {
             put("properties", JSONObject())
         }
         val order = JSONArray()
+        val notCopiedKeys = copyTarget().keySet() + "order"+"properties"
         getAllObjectsInAllOf(allOf).forEach { propObj ->
             merge(copyTarget().getJSONObject("properties"), propObj.getJSONObject("properties"))
             propObj.optJSONArray("order")?.also { order.put(it) }
             propObj.optJSONObject("order")?.also { order.put(it) }
-            merge(copyTarget(), propObj, copyTarget().keySet())
+            merge(copyTarget(), propObj, notCopiedKeys)
         }
         if (!order.isEmpty) {
             copyTarget().put("order", order)

--- a/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
@@ -12,35 +12,35 @@ class SchemaNormalizationTest {
     @Test
     fun resolveSimpleRef() {
         val schema =
-                JSONObject(
-                        """{"definitions": {"test": {"type":"string"}},
+            JSONObject(
+                """{"definitions": {"test": {"type":"string"}},
                 "type":"object","properties":{"string":{"${'$'}ref": "#/definitions/test"}}}"""
-                )
+            )
         val result = SchemaNormalizer.resolveRefs(schema, null)
         assertThat(
-                result.getJSONObject("properties").getJSONObject("string").getString("type"),
-                `is`("string")
+            result.getJSONObject("properties").getJSONObject("string").getString("type"),
+            `is`("string")
         )
     }
 
     @Test
     fun resolveRootRef() {
         val objSchema =
-                JSONObject("""{"type":"object","properties":{"string":{"type":"string"}}}""")
+            JSONObject("""{"type":"object","properties":{"string":{"type":"string"}}}""")
         val schema = JSONObject().put("definitions", JSONArray().put(objSchema))
-                .put("${'$'}ref", "#/definitions/0")
+            .put("${'$'}ref", "#/definitions/0")
         val result = SchemaNormalizer.resolveRefs(schema, null)
         assertThat(
-                result.getJSONObject("properties").getJSONObject("string").getString("type"),
-                `is`("string")
+            result.getJSONObject("properties").getJSONObject("string").getString("type"),
+            `is`("string")
         )
     }
 
     @Test
     fun resolveAllOfRef() {
         val schema =
-                JSONObject(
-                        """{"definitions": [ 
+            JSONObject(
+                """{"definitions": [ 
                     {
                       "type":"object","properties": {"string0":{"type":"string"}}
                     },
@@ -51,26 +51,26 @@ class SchemaNormalizationTest {
                 "allOf":[
                 {"${'$'}ref": "#/definitions/0"}, {"${'$'}ref": "#/definitions/1"}
                 ]}"""
-                )
+            )
 
         val result = SchemaNormalizer.resolveRefs(schema, null)
         println(schema.toString(1))
         assertThat(
-                result.getJSONArray("allOf").getJSONObject(0).getJSONObject("properties")
-                        .getJSONObject("string0").getString("type"),
-                `is`("string")
+            result.getJSONArray("allOf").getJSONObject(0).getJSONObject("properties")
+                .getJSONObject("string0").getString("type"),
+            `is`("string")
         )
         assertThat(
-                result.getJSONArray("allOf").getJSONObject(1).getJSONObject("properties")
-                        .getJSONObject("string1").getString("type"),
-                `is`("string")
+            result.getJSONArray("allOf").getJSONObject(1).getJSONObject("properties")
+                .getJSONObject("string1").getString("type"),
+            `is`("string")
         )
     }
 
     @Test
     fun mergesAllOfs() {
         val schema = JSONObject(
-                """{"allOf": [ 
+            """{"allOf": [ 
                     {
                       "type":"object", 
                       "properties": {"string0":{"type":"string"},"int0": {"type": "integer"}},
@@ -109,7 +109,8 @@ class SchemaNormalizationTest {
 
     @Test
     fun mergesPartialRef() {
-        val schema = JSONObject("""
+        val schema = JSONObject(
+            """
 {
   "definitions": {
     "foo": {
@@ -133,7 +134,8 @@ class SchemaNormalizationTest {
     }
   }
 }
-        """)
+        """
+        )
 
         val result = SchemaNormalizer.resolveRefs(schema, null)
         val properties = result.getJSONObject("properties")
@@ -158,8 +160,12 @@ class SchemaNormalizationTest {
         val schema = javaClass.classLoader.getResourceAsStream("nestedCompositeSchema.json").use {
             JSONObject(JSONTokener(it))
         }
-        val result = SchemaNormalizer.normalizeSchema(schema, javaClass.classLoader.getResource("").toURI())
-        assertThat(result.toString(1), `is`(JSONObject("""{
+        val result =
+            SchemaNormalizer.normalizeSchema(schema, javaClass.classLoader.getResource("").toURI())
+        assertThat(
+            result.toString(1), `is`(
+                JSONObject(
+                    """{
  "${'$'}schema": "http://json-schema.org/draft-07/schema",
  "title": "composite",
  "type": "object",
@@ -179,14 +185,16 @@ class SchemaNormalizationTest {
   "y": {"type": "number"}
  }
 }
-""").toString(1))
+"""
+                ).toString(1)
+            )
         )
     }
 
     @Test
     fun correctlyMergesOrderWhenArray() {
         val schema = JSONObject(
-                """{"allOf": [ 
+            """{"allOf": [ 
     {
       "type":"object", 
       "properties": {"string0":{"type":"string"},"int0": {"type": "integer"}},
@@ -200,13 +208,16 @@ class SchemaNormalizationTest {
     ]}"""
         )
         val result = SchemaNormalizer.convertOrder(SchemaNormalizer.inlineCompositions(schema))
-        assertThat(result.getJSONArray("order").toList(), contains("int0", "string0", "string1", "int1"))
+        assertThat(
+            result.getJSONArray("order").toList(),
+            contains("int0", "string0", "string1", "int1")
+        )
     }
 
     @Test
     fun correctlyMergesOrderWhenMixed() {
         val schema = JSONObject(
-                """{"allOf": [ 
+            """{"allOf": [ 
     {
       "type":"object", 
       "properties": {"string0":{"type":"string"},"int0": {"type": "integer"}},
@@ -220,13 +231,16 @@ class SchemaNormalizationTest {
     ]}"""
         )
         val result = SchemaNormalizer.convertOrder(SchemaNormalizer.inlineCompositions(schema))
-        assertThat(result.getJSONArray("order").toList(), contains("int0", "string0", "int1", "string1"))
+        assertThat(
+            result.getJSONArray("order").toList(),
+            contains("int0", "string0", "int1", "string1")
+        )
     }
 
     @Test
     fun correctlyMergesOrderWhenObject() {
         val schema = JSONObject(
-                """{"allOf": [ 
+            """{"allOf": [ 
     {
       "type":"object", 
       "properties": {"string0":{"type":"string"},"int0": {"type": "integer"}},
@@ -237,15 +251,19 @@ class SchemaNormalizationTest {
       "properties": {"string1":{"type":"string"},"int1": {"type": "integer"}},
       "order": {"string1": 4,"int1": 800}
     }
-    ]}""")
+    ]}"""
+        )
         val result = SchemaNormalizer.convertOrder(SchemaNormalizer.inlineCompositions(schema))
-        assertThat(result.getJSONArray("order").toList(), contains("int0", "string1", "string0", "int1"))
+        assertThat(
+            result.getJSONArray("order").toList(),
+            contains("int0", "string1", "string0", "int1")
+        )
     }
 
     @Test
     fun ensureCorrectOrderFormat() {
         val schema = JSONObject(
-                """{
+            """{
       "type":"object", 
       "properties": {"obj0":{
       "type":"object",
@@ -253,12 +271,15 @@ class SchemaNormalizationTest {
       "order": {"string1": 4000,"int1": 800}
       },"int0": {"type": "integer"}},
       "order": {"int0": 1,"obj0": 7}
-    }""")
+    }"""
+        )
 
         val result = SchemaNormalizer.convertOrder(schema)
         assertThat(result.getJSONArray("order").toList(), contains("int0", "obj0"))
-        assertThat(result.getJSONObject("properties").getJSONObject("obj0")
-                .getJSONArray("order").toList(), contains("int1", "string1"))
+        assertThat(
+            result.getJSONObject("properties").getJSONObject("obj0")
+                .getJSONArray("order").toList(), contains("int1", "string1")
+        )
     }
 
     @Test
@@ -266,7 +287,7 @@ class SchemaNormalizationTest {
         val uri = this::class.java.classLoader.getResource("")?.toURI()
 
         val schema = JSONObject(
-                """
+            """
 {
   "type": "object",
   "properties": {
@@ -275,7 +296,8 @@ class SchemaNormalizationTest {
     }
   }
 }
-""")
+"""
+        )
 
         val result = SchemaNormalizer.resolveRefs(schema, uri)
 
@@ -287,7 +309,7 @@ class SchemaNormalizationTest {
         val uri = this::class.java.classLoader.getResource("")?.toURI()
 
         val schema = JSONObject(
-                """
+            """
 {
   "type": "object",
   "properties": {
@@ -296,7 +318,8 @@ class SchemaNormalizationTest {
     }
   }
 }
-""")
+"""
+        )
 
         val result = SchemaNormalizer.resolveRefs(schema, uri)
 
@@ -309,7 +332,8 @@ class SchemaNormalizationTest {
     fun testRefToFragmentInDifferentFile() {
         val uri = this::class.java.classLoader.getResource("")?.toURI()
 
-        val schema = JSONObject("""
+        val schema = JSONObject(
+            """
             {
               "properties": {
                 "a": {
@@ -317,7 +341,8 @@ class SchemaNormalizationTest {
                 }
               }
             }
-        """.trimIndent())
+        """.trimIndent()
+        )
 
         val result = SchemaNormalizer.resolveRefs(schema, uri)
 
@@ -327,7 +352,7 @@ class SchemaNormalizationTest {
     @Test
     fun testRefInsideDefinitions() {
         val schema = JSONObject(
-                """
+            """
 {
   "definitions": {
     "a": {
@@ -355,7 +380,8 @@ class SchemaNormalizationTest {
     }
   }
 }
-""")
+"""
+        )
         val result = SchemaNormalizer.resolveRefs(schema, null)
 
         assertThat(result.query("#/properties/foo/type"), `is`("integer"))
@@ -367,7 +393,7 @@ class SchemaNormalizationTest {
     fun refInAdditionalProperties() {
         val uri = this::class.java.classLoader.getResource("")?.toURI()
         val schema = JSONObject(
-                """
+            """
 {
   "type": "object",
   "properties": {
@@ -379,9 +405,55 @@ class SchemaNormalizationTest {
     }
   }
 }
-""")
+"""
+        )
         val result = SchemaNormalizer.resolveRefs(schema, uri)
 
         assertThat(result.query("#/properties/foo/additionalProperties/type"), `is`("object"))
+    }
+
+    @Test
+    fun deeplyNestedRequired() {
+        val schema = JSONObject(
+            """
+           {"allOf": [
+ {"allOf": [
+  {
+   "type": "object",
+   "properties": {
+    "layer": {"type": "integer"}
+   },
+   "required": [
+    "layer",
+    "non-existent"
+   ]
+  },
+  {
+   "type": "object",
+   "properties": {
+    "text": {"type": "string"},
+   },
+   "required": [
+    "text",
+   ]
+  }
+ ]},
+ {
+  "type": "object",
+  "properties": {
+   "id": {"type": "string"}
+  },
+  "required": [
+   "id",
+  ]
+ }
+]} 
+        """
+        )
+
+        assertThat(
+            SchemaNormalizer.normalizeSchema(schema, null).getJSONArray("required"),
+            containsInAnyOrder("id", "text", "non-existent", "layer")
+        )
     }
 }

--- a/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/SchemaNormalizationTest.kt
@@ -24,6 +24,31 @@ class SchemaNormalizationTest {
     }
 
     @Test
+    fun resolveSimpleRefTwice() {
+        val schema =
+            JSONObject(
+                """{"definitions": {"test": {
+                    "type":"array",
+                    "items":{
+                    "type":"string"
+                    }
+                    }},
+                "type":"object","properties":{
+                "strings":{"${'$'}ref": "#/definitions/test"},
+                "strings2":{"${'$'}ref": "#/definitions/test"}
+                }}
+                """
+            )
+        val result = SchemaNormalizer.resolveRefs(schema, null)
+        result.getJSONObject("properties").getJSONObject("strings").getJSONObject("items")
+            .put("title", "foo")
+        assertThat(
+            result.getJSONObject("properties").getJSONObject("strings2").getJSONObject("items")
+                .has("title"), `is`(false)
+        )
+    }
+
+    @Test
     fun resolveRootRef() {
         val objSchema =
             JSONObject("""{"type":"object","properties":{"string":{"type":"string"}}}""")

--- a/src/test/kotlin/com/github/hanseter/json/editor/base/SimilarObjectMatcher.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/base/SimilarObjectMatcher.kt
@@ -1,0 +1,21 @@
+package com.github.hanseter.json.editor.base
+
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+import org.json.JSONObject
+
+class SimilarObjectMatcher(
+    private val reference: JSONObject
+) : TypeSafeMatcher<JSONObject>(JSONObject::class.java) {
+
+    override fun describeTo(description: Description) {
+        description.appendText("Should be similar to")
+            .appendValue(reference)
+    }
+
+    override fun matchesSafely(item: JSONObject): Boolean {
+        return reference.similar(item)
+    }
+
+
+}

--- a/src/test/kotlin/com/github/hanseter/json/editor/normalizaton/AllOfNormalizationTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/normalizaton/AllOfNormalizationTest.kt
@@ -1,0 +1,186 @@
+package com.github.hanseter.json.editor.normalizaton
+
+import com.github.hanseter.json.editor.SchemaNormalizer
+import com.github.hanseter.json.editor.base.SimilarObjectMatcher
+import org.hamcrest.MatcherAssert
+import org.json.JSONObject
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+
+class AllOfNormalizationTest {
+
+    private fun generateTests(inputSchemas: List<JSONObject>, mergedSchema: JSONObject): List<DynamicTest> {
+        val inputSchemaCombinations = inputSchemas.fold(emptyList()) { acc: List<List<Pair<JSONObject, Boolean>>>, current ->
+            if (acc.isEmpty()) {
+                listOf(listOf(current to true), listOf(current to false))
+            } else acc.flatMap { listOf(it + (current to true), it + (current to false)) }
+        }
+
+        return inputSchemaCombinations
+            .map { schemas -> DynamicTest.dynamicTest(
+                schemas.withIndex().joinToString {
+                    "Schema #${it.index} ${if (it.value.second) "${'$'}ref" else "inline"}"
+                }
+            ) {
+                val input = JSONObject()
+                    .put("type", "object")
+
+                val definitions = JSONObject().also { input.put("definitions", it) }
+
+                for (schema in schemas.withIndex().filter { it.value.second }) {
+                    definitions.put("schema${schema.index}", schema.value.first)
+                }
+
+                input.put("properties", JSONObject().put("sub", JSONObject().put("allOf", schemas.withIndex().map {
+                    if (it.value.second) {
+                        JSONObject().put("${'$'}ref", "#/definitions/schema${it.index}")
+                    } else {
+                        it.value.first
+                    }
+                })))
+
+                val normalized = SchemaNormalizer.normalizeSchema(input, null)
+
+                val expected = JSONObject()
+                    .put("type", "object")
+                    .put("definitions", definitions)
+                    .put("properties", JSONObject().put("sub", mergedSchema))
+
+                MatcherAssert.assertThat(normalized, SimilarObjectMatcher(expected))
+            } }
+    }
+
+    @TestFactory
+    fun `key overriding`(): List<DynamicTest> {
+        return generateTests(
+            listOf(
+                stringPropWithDate(),
+                stringPropWithDateTime()
+            ),
+            stringPropWithDateTime()
+        )
+    }
+
+    @TestFactory
+    fun `property merging`(): List<DynamicTest> {
+        return generateTests(
+            listOf(
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("foo", JSONObject().put("type", "boolean"))),
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("bar", JSONObject().put("type", "number"))),
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("baz", JSONObject().put("type", "integer").put("title", "Baz")))
+            ),
+            JSONObject()
+                .put("type", "object")
+                .put("properties", JSONObject()
+                    .put("foo", JSONObject().put("type", "boolean"))
+                    .put("bar", JSONObject().put("type", "number"))
+                    .put("baz", JSONObject().put("type", "integer").put("title", "Baz"))
+                )
+        )
+    }
+
+    @TestFactory
+    fun `order merging`(): List<DynamicTest> {
+        return generateTests(
+            listOf(
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("foo", JSONObject().put("type", "boolean"))
+                        .put("foo2", JSONObject().put("type", "boolean"))
+                    )
+                    .put("order", listOf("foo2", "foo")),
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("bar", JSONObject().put("type", "number"))
+                        .put("bar2", JSONObject().put("type", "number"))
+                    )
+                    .put("order", mapOf("bar" to 1000)),
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("baz", JSONObject().put("type", "integer").put("title", "Baz"))
+                        .put("baz2", JSONObject().put("type", "integer"))
+                    )
+                    .put("order", mapOf("baz" to 10, "baz2" to 20))
+            ),
+            JSONObject()
+                .put("type", "object")
+                .put("properties", JSONObject()
+                    .put("foo", JSONObject().put("type", "boolean"))
+                    .put("foo2", JSONObject().put("type", "boolean"))
+                    .put("bar", JSONObject().put("type", "number"))
+                    .put("bar2", JSONObject().put("type", "number"))
+                    .put("baz", JSONObject().put("type", "integer").put("title", "Baz"))
+                    .put("baz2", JSONObject().put("type", "integer"))
+                )
+                .put("order", listOf("foo2", "foo", "baz", "baz2", "bar"))
+        )
+    }
+
+    @TestFactory
+    fun `required merging`(): List<DynamicTest> {
+        return generateTests(
+            listOf(
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("foo", JSONObject().put("type", "boolean"))
+                        .put("foo2", JSONObject().put("type", "boolean"))
+                    )
+                    .put("required", listOf("foo2")),
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("bar", JSONObject().put("type", "number"))
+                        .put("bar2", JSONObject().put("type", "number"))
+                    )
+                    .put("required", listOf("bar")),
+                JSONObject()
+                    .put("type", "object")
+                    .put("properties", JSONObject()
+                        .put("baz", JSONObject().put("type", "integer").put("title", "Baz"))
+                        .put("baz2", JSONObject().put("type", "integer"))
+                    )
+            ),
+            JSONObject()
+                .put("type", "object")
+                .put("properties", JSONObject()
+                    .put("foo", JSONObject().put("type", "boolean"))
+                    .put("foo2", JSONObject().put("type", "boolean"))
+                    .put("bar", JSONObject().put("type", "number"))
+                    .put("bar2", JSONObject().put("type", "number"))
+                    .put("baz", JSONObject().put("type", "integer").put("title", "Baz"))
+                    .put("baz2", JSONObject().put("type", "integer"))
+                )
+                .put("required", listOf("foo2", "bar"))
+        )
+    }
+
+    companion object {
+
+        val stringPropWithDate = {
+            JSONObject()
+                .put("type", "string")
+                .put("format", "date")
+        }
+
+        val stringPropWithDateTime = {
+            JSONObject()
+                .put("type", "string")
+                .put("format", "date-time")
+        }
+
+    }
+
+}


### PR DESCRIPTION
Changes how `allOf`s are resolved during schema normalization. Mostly adds support for merging non-object schemas. Also backports the schema normalization fixes made in the `master` branch to Java 8.