### PR TITLE
Fix some thread weirdness when calling `updateObject` too early.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>0.0.48</version>
+    <version>0.0.49</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -167,9 +167,10 @@ class JsonPropertiesPane(
         objectControl?.bindTo(type)
         fillTree(data)
         type.registerListener {
-            val newData = changeListener(PropertiesEditInput(type.getValue()!!, rawSchema))
 
             Platform.runLater {
+                val newData = changeListener(PropertiesEditInput(type.getValue()!!, rawSchema))
+
                 if (newData.schema != null) {
 
                     rawSchema = newData.schema


### PR DESCRIPTION
What it says on the tin. We had a threading problem where calling `updateObject` while the `Platform.runLater` call from the internal change callback was still queued caused issues where the UI didn't sync properly.