### PR TITLE
Fix thumbs in toggle switches not moving if set programmatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/controls/MultiLineStringControl.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/controls/MultiLineStringControl.kt
@@ -6,6 +6,9 @@ import javafx.scene.control.TextArea
 import javafx.scene.control.skin.TextAreaSkin
 
 class MultiLineStringControl : ControlWithProperty<String?> {
+
+    private var scrollBarPolicy: ScrollPane.ScrollBarPolicy = ScrollPane.ScrollBarPolicy.NEVER
+
     override val control: TextArea = TextArea().apply {
         maxHeight = 26.0
         prefHeightProperty().bind(maxHeightProperty())
@@ -19,10 +22,16 @@ class MultiLineStringControl : ControlWithProperty<String?> {
                 setHorizonzalScrollbarPolicy(ScrollPane.ScrollBarPolicy.NEVER)
             }
         }
+        skinProperty().addListener { _, _, new ->
+            if (new != null) {
+                setHorizonzalScrollbarPolicy(scrollBarPolicy)
+            }
+        }
     }
 
     private fun TextArea.setHorizonzalScrollbarPolicy(policy: ScrollPane.ScrollBarPolicy) {
-        ((skin as TextAreaSkin).children.single() as ScrollPane).hbarPolicy = policy
+        scrollBarPolicy = policy
+        ((skin as? TextAreaSkin)?.children?.single() as? ScrollPane)?.hbarPolicy = policy
     }
 
     override val property: Property<String?>

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/skins/ToggleSwitchSkin.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/skins/ToggleSwitchSkin.kt
@@ -62,17 +62,17 @@ class ToggleSwitchSkin(checkBox: CheckBox) : LabeledSkinBase<CheckBox>(checkBox)
         // Stop the transition if it was already running, has no effect otherwise.
         transition.stop()
 
-            if (skinnable.isSelected) {
-                transition.rate = 1.0
-                transition.jumpTo(Duration.ZERO)
-            } else {
-                // If we are not selected, we need to go from right to left.
-                transition.rate = -1.0
-                transition.jumpTo(transition.duration)
-            }
+        transition.rate = if (skinnable.isSelected) 1.0 else -1.0
+
+        // we jump the selection to the start based on the current direction (-duration will be coerced to 0)
+        transition.jumpTo(transition.duration.multiply(-transition.rate))
+
         if (skinnable.isArmed || skinnable.isFocused) {
             transition.play()
+        } else {
+            skinnable.requestLayout()
         }
+
     }
 
     override fun computeMinWidth(

--- a/src/test/kotlin/com/github/hanseter/json/editor/ToggleSwitchTestApp.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/ToggleSwitchTestApp.kt
@@ -1,0 +1,53 @@
+package com.github.hanseter.json.editor
+
+import com.github.hanseter.json.editor.ui.skins.ToggleSwitchSkin
+import javafx.application.Application
+import javafx.geometry.Insets
+import javafx.scene.Scene
+import javafx.scene.control.CheckBox
+import javafx.scene.layout.VBox
+import javafx.stage.Stage
+
+fun main() {
+    Application.launch(ToggleSwitchTestApp::class.java)
+}
+
+class ToggleSwitchTestApp : Application() {
+
+
+    override fun start(primaryStage: Stage) {
+
+        val switch1 = CheckBox().apply {
+            text = "Switch 1"
+            skin = ToggleSwitchSkin(this)
+        }
+        val switch2 = CheckBox().apply {
+            id = "switch2"
+            text = "Switch 2"
+            skin = ToggleSwitchSkin(this)
+        }
+        val switch3 = CheckBox().apply {
+            text = "Switch 3"
+            isSelected = true
+            skin = ToggleSwitchSkin(this)
+        }
+
+        switch1.selectedProperty().addListener { _, _, new ->
+            switch2.isSelected = new
+        }
+
+        val root = VBox(16.0,
+            switch1, switch2, switch3
+        ).apply {
+            padding = Insets(32.0)
+        }
+
+        primaryStage.apply {
+            title = "Toggle Switches Galore"
+            scene = Scene(root)
+        }
+
+        primaryStage.show()
+    }
+
+}


### PR DESCRIPTION
Toggle switch thumbs would only change their color if `setSelected` is invoked while the button is not armed/focused. Now it updates correctly. A tiny test app was added to study toggle switch behavior.

Also, fixes a NPE that occurred in multi-line string controls.