### PR TITLE
Allow changing validators after creation

### DIFF
--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
@@ -12,7 +12,6 @@ import javafx.collections.ObservableList
 import javafx.collections.transformation.FilteredList
 import javafx.event.Event
 import javafx.scene.control.TreeItem
-import org.controlsfx.validation.Severity
 
 /**
  * Creates a filterable TreeItem with children.
@@ -122,7 +121,6 @@ class ControlTreeItemData(
     private val actions: List<EditorAction>,
     private val actionHandler: (Event, EditorAction, TypeControl) -> Unit,
     private val objId: String,
-    val validators: List<Validator>,
     private val customizationObject: CustomizationObject
 ) : TreeItemData {
     private val changeListeners: MutableList<(TreeItemData) -> Unit> = mutableListOf()

--- a/src/test/kotlin/com/github/hanseter/json/editor/ValidationTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/ValidationTest.kt
@@ -59,4 +59,92 @@ class ValidationTest {
         MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(false))
     }
 
+    @Test
+    fun `additional validators are used if registered later`() {
+        val editor = JsonPropertiesEditor()
+
+        val schema = JSONObject("""
+{
+  "properties": {
+    "a": {
+      "type": "string"
+    }
+  }
+}
+        """)
+
+        editor.display("1", "1", JSONObject().put("a", "foo"), schema) { it }
+
+        WaitForAsyncUtils.waitForFxEvents()
+        MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(true))
+
+        editor.additionalValidators += object : Validator {
+            override val selector: TargetSelector
+                get() = TargetSelector.SchemaType(SupportedType.SimpleType.StringType)
+
+            override fun validate(model: TypeModel<*, *>, objId: String): List<Validator.ValidationResult> {
+                return if (model.value == "foo") {
+                    emptyList()
+                } else listOf(Validator.SimpleValidationResult(Severity.ERROR, "error"))
+            }
+
+        }
+
+        WaitForAsyncUtils.waitForFxEvents()
+        MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(true))
+
+        val stringControl = editor.getControlInTable("a") as TextField
+
+        stringControl.text = "bar"
+
+        WaitForAsyncUtils.waitForFxEvents()
+        MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(false))
+    }
+
+    @Test
+    fun `changing validators triggers validation`() {
+        val editor = JsonPropertiesEditor()
+
+        val schema = JSONObject("""
+{
+  "properties": {
+    "a": {
+      "type": "string"
+    }
+  }
+}
+        """)
+
+        editor.display("1", "1", JSONObject().put("a", "foo"), schema) { it }
+
+        WaitForAsyncUtils.waitForFxEvents()
+        MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(true))
+
+        val stringControl = editor.getControlInTable("a") as TextField
+
+        stringControl.text = "bar"
+
+        WaitForAsyncUtils.waitForFxEvents()
+        MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(true))
+
+        editor.additionalValidators += object : Validator {
+            override val selector: TargetSelector
+                get() = TargetSelector.SchemaType(SupportedType.SimpleType.StringType)
+
+            override fun validate(model: TypeModel<*, *>, objId: String): List<Validator.ValidationResult> {
+                return if (model.value == "foo") {
+                    emptyList()
+                } else listOf(Validator.SimpleValidationResult(Severity.ERROR, "error"))
+            }
+        }
+
+        WaitForAsyncUtils.waitForFxEvents()
+        MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(false))
+
+        editor.additionalValidators = emptyList()
+
+        WaitForAsyncUtils.waitForFxEvents()
+        MatcherAssert.assertThat(editor.valid.get(), Matchers.`is`(true))
+    }
+
 }


### PR DESCRIPTION
Adds a mutable `additionalValidators` field to the editor that can be used to add/remove validators after the creation of the editor.