### PR TITLE
Allow changing the customization object after creating the editor.

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21.0.4-tem
+java=17.0.10-tem

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.hanseter</groupId>
     <artifactId>json-properties-fx</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
 
     <packaging>bundle</packaging>
     <name>JSON Properties Editor Fx</name>

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesEditor.kt
@@ -25,7 +25,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
     private val readOnly: Boolean = false,
     viewOptions: ViewOptions = ViewOptions(),
     actions: List<EditorAction> = listOf(ResetToDefaultAction, ResetToNullAction),
-    private val customizationObject: CustomizationObject = DefaultCustomizationObject,
+    customizationObject: CustomizationObject = DefaultCustomizationObject,
     additionalValidators: List<Validator> = emptyList()
 ) : StackPane() {
     var referenceProposalProvider: IdReferenceProposalProvider =
@@ -49,6 +49,17 @@ class JsonPropertiesEditor @JvmOverloads constructor(
             Platform.runLater {
                 idsToPanes.values.forEach {
                     it.revalidate()
+                }
+            }
+        }
+
+    var customizationObject: CustomizationObject = customizationObject
+        set(value) {
+            field = value
+
+            Platform.runLater {
+                idsToPanes.values.forEach {
+                    it.rebuildControlTree()
                 }
             }
         }
@@ -121,7 +132,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
             title, objId, obj,
             schema,
             readOnly,
-            resolutionScope, customizationObject, callback
+            resolutionScope, callback
         )
         pane.fillData(obj)
         idsToPanes[objId] = pane
@@ -211,7 +222,6 @@ class JsonPropertiesEditor @JvmOverloads constructor(
     private fun createTitledPaneForSchema(
         title: String, objId: String, data: JSONObject,
         rawSchema: JSONObject, readOnly: Boolean, resolutionScope: URI?,
-        customizationObject: CustomizationObject,
         callback: OnEditCallback
     ): JsonPropertiesPane =
         JsonPropertiesPane(
@@ -225,7 +235,7 @@ class JsonPropertiesEditor @JvmOverloads constructor(
             actions,
             { validators },
             viewOptions,
-            customizationObject,
+            { customizationObject },
             callback
         )
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/JsonPropertiesPane.kt
@@ -32,7 +32,7 @@ class JsonPropertiesPane(
     private val actions: List<EditorAction>,
     private val validators: () -> List<Validator>,
     viewOptions: ViewOptions,
-    private val customizationObject: CustomizationObject,
+    private val customizationObject: () -> CustomizationObject,
     private val changeListener: JsonPropertiesEditor.OnEditCallback
 ) {
     val treeItem: FilterableTreeItem<TreeItemData> =
@@ -80,7 +80,7 @@ class JsonPropertiesPane(
         createControlTree()
     }
 
-    private fun rebuildControlTree() {
+    fun rebuildControlTree() {
 
         val uiState = saveUiState()
 

--- a/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
+++ b/src/main/kotlin/com/github/hanseter/json/editor/ui/FilterableTreeItem.kt
@@ -121,15 +121,15 @@ class ControlTreeItemData(
     private val actions: List<EditorAction>,
     private val actionHandler: (Event, EditorAction, TypeControl) -> Unit,
     private val objId: String,
-    private val customizationObject: CustomizationObject
+    private val customizationObject: () -> CustomizationObject
 ) : TreeItemData {
     private val changeListeners: MutableList<(TreeItemData) -> Unit> = mutableListOf()
 
     override val title: String
-        get() = customizationObject.getTitle(typeControl.model, typeControl.model.schema.title)
+        get() = customizationObject().getTitle(typeControl.model, typeControl.model.schema.title)
 
     override val description: String?
-        get() = customizationObject.getDescription(typeControl.model, typeControl.model.schema.description)
+        get() = customizationObject().getDescription(typeControl.model, typeControl.model.schema.description)
 
     override val required: Boolean
         get() = typeControl.model.schema.required

--- a/src/test/kotlin/com/github/hanseter/json/editor/CustomizationObjectTest.kt
+++ b/src/test/kotlin/com/github/hanseter/json/editor/CustomizationObjectTest.kt
@@ -106,4 +106,43 @@ class CustomizationObjectTest {
 
     }
 
+    @Test
+    fun `customization can be changed after creation`() {
+        val schema = JSONObject("""
+{
+    "type":"object",
+    "properties": {
+        "foo": {
+            "type": "string"
+        },
+        "notFoo": {
+            "type": "string"
+        }
+    }
+}""")
+        val editor = JsonPropertiesEditor()
+
+        val json = JSONObject("""{"foo":""}""")
+        editor.display("1", "1", json, schema) { it }
+
+        val fooCell = editor.getKeyCellInTable("foo")
+
+        MatcherAssert.assertThat((fooCell.graphic as Labeled).text, Matchers.`is`("foo"))
+
+        editor.customizationObject = object : CustomizationObject {
+
+            override fun getTitle(model: TypeModel<*, *>, defaultTitle: String): String {
+                if (model.schema.pointer == listOf("foo")) {
+                    return "bar"
+                }
+                return defaultTitle
+            }
+
+        }
+
+        WaitForAsyncUtils.waitForFxEvents()
+        val fooCellNew = editor.getKeyCellInTable("bar")
+        MatcherAssert.assertThat((fooCellNew.graphic as Labeled).text, Matchers.`is`("bar"))
+    }
+
 }


### PR DESCRIPTION
Makes the customization object mutable.

Also changes the JDK version for SDKMan to a Java 17 one. Obviously, this should be reverted once merged into `master`.